### PR TITLE
Fixed BOP Mangrove bug.

### DIFF
--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMapleWoods.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMapleWoods.java
@@ -12,7 +12,7 @@ import biomesoplenty.api.content.BOPCBiomes;
 
 public class RealisticBiomeBOPMapleWoods extends RealisticBiomeBOPBase
 {	
-	public static BiomeGenBase bopBiome = BOPCBiomes.mangrove;
+	public static BiomeGenBase bopBiome = BOPCBiomes.mapleWoods;
 	
 	public static Block topBlock = bopBiome.topBlock;
 	public static Block fillerBlock = bopBiome.fillerBlock;


### PR DESCRIPTION
Due to a typo, the BOP Mangrove biome was generating even though it was
disabled in the RTG configs. This commit fixes the typo.