### PR TITLE
Fix wrong encoding in .lang files

### DIFF
--- a/src/main/resources/assets/RTG/lang/fr_FR.lang
+++ b/src/main/resources/assets/RTG/lang/fr_FR.lang
@@ -1,1 +1,1 @@
-﻿generator.RTG=Réaliste
+generator.RTG=Réaliste

--- a/src/main/resources/assets/RTG/lang/ko_KR.lang
+++ b/src/main/resources/assets/RTG/lang/ko_KR.lang
@@ -1,1 +1,1 @@
-﻿generator.RTG=현실적인 바이옴
+generator.RTG=현실적인 바이옴

--- a/src/main/resources/assets/RTG/lang/ru_RU.lang
+++ b/src/main/resources/assets/RTG/lang/ru_RU.lang
@@ -1,1 +1,1 @@
-﻿generator.RTG=Pеалистичный
+generator.RTG=Реалистичный

--- a/src/main/resources/assets/RTG/lang/zh_CN.lang
+++ b/src/main/resources/assets/RTG/lang/zh_CN.lang
@@ -1,1 +1,1 @@
-﻿generator.RTG=真实世界生成初版
+generator.RTG=真实世界生成


### PR DESCRIPTION
Converted UTF-8 BOM encoding to UTF-8 (Minecraft can't read UTF-8 BOM encoding)
Changed Chinese localization from "真实世界生成初版" (which Google translates as "Real world generation first edition (alpha version)) to "真实世界生成" which means just "Real world generation".