### PR TITLE
Updating for snapshot

### DIFF
--- a/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
+++ b/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
@@ -96,7 +96,11 @@ public class WorldChunkManagerRTG extends WorldChunkManager
         for (int i1 = 0; i1 < par4 * par5; ++i1)
         {
             float f = 0;
-            f = (float) RealisticBiomeBase.getBiome(aint[i1]).getIntRainfall() / 65536.0F;
+            try {
+                f = (float) RealisticBiomeBase.getBiome(aint[i1]).getIntRainfall() / 65536.0F;
+            } catch (Exception e) {
+                throw new RuntimeException("problem with biome "+aint[i1]);
+            }
             if (f > 1.0F)
             {
                 f = 1.0F;

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLAutumnForest.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLAutumnForest.java
@@ -20,7 +20,7 @@ public class RealisticBiomeHLAutumnForest extends RealisticBiomeHLBase {
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.COLD),
-            new TerrainHLAutumnForest(0f, 140f, 68f, 200f),
+            new TerrainHLAutumnForest(0f, 50f, 68f, 200f),
             new SurfaceHLAutumnForest(topBlock, fillerBlock));
         
         this.setRealisticBiomeName("HL Autumn Forest");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLBaldHill.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLBaldHill.java
@@ -21,7 +21,7 @@ public class RealisticBiomeHLBaldHill extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE),
-            new TerrainHLBaldHill(90f, 180f, 13f, 100f, 38f, 260f, 71f),
+            new TerrainHLBaldHill(90f, 180f, 13f, 100f, 38f, 260f, 81f),
             new SurfaceHLBaldHill(topBlock, fillerBlock)
         );
         

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLBirchHills.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLBirchHills.java
@@ -19,7 +19,7 @@ public class RealisticBiomeHLBirchHills extends RealisticBiomeHLBase
     public RealisticBiomeHLBirchHills()
     {
     
-        super(hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE), new TerrainHLBirchHills(230f, 120f, 0f),
+        super(hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE), new TerrainHLBirchHills(230f, 60f, 0f),
             new SurfaceHLBirchHills(topBlock, fillerBlock, false, null, 0.95f));
         
         this.setRealisticBiomeName("HL Birch Hills");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLCliffs.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLCliffs.java
@@ -21,7 +21,7 @@ public class RealisticBiomeHLCliffs extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.COLD),
-            new TerrainHLCliffs(230f, 120f, 0f),
+            new TerrainHLCliffs(75f, 70f, 0f),
             new SurfaceHLCliffs(topBlock, fillerBlock, false, null, 0.95f));
         
         this.setRealisticBiomeName("HL Cliffs");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLHighlandsB.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLHighlandsB.java
@@ -22,7 +22,7 @@ public class RealisticBiomeHLHighlandsB extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.COLD),
-            new TerrainHLHighlandsB(0f, 140f, 68f, 150f),
+            new TerrainHLHighlandsB(15f, 60f, 68f, 150f),
             new SurfaceHLHighlandsB(topBlock, fillerBlock, false, null, 1f, 1.5f, 85f, 20f, 4f));
         
         this.setRealisticBiomeName("HL HighlandsB");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLRainforest.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLRainforest.java
@@ -22,7 +22,7 @@ public class RealisticBiomeHLRainforest extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.WET),
-            new TerrainHLRainforest(120f, 300f),
+            new TerrainHLRainforest(120f, 300f,8f),
             new SurfaceHLRainforest(topBlock, fillerBlock, false, null, 1.3f));
         
         this.setRealisticBiomeName("HL Rainforest");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLRedwoodForest.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLRedwoodForest.java
@@ -22,7 +22,7 @@ public class RealisticBiomeHLRedwoodForest extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.COLD),
-            new TerrainHLRedwoodForest(80f, 180f, 13f, 100f, 38f, 260f, 71f),
+            new TerrainHLRedwoodForest(40f, 180f, 13f, 100f, 38f, 260f, 71f),
             new SurfaceHLRedwoodForest(topBlock, fillerBlock, false, null, 0.4f));
         
         this.setRealisticBiomeName("HL Redwood Forest");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLShrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLShrubland.java
@@ -22,7 +22,7 @@ public class RealisticBiomeHLShrubland extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE),
-            new TerrainHLShrubland(70f, 150f, 13f, 90f, 38f, 200f, 71f),
+            new TerrainHLShrubland(10f, 20f, 7f, 90f, 10f, 200f, 68f),
             new SurfaceHLShrubland(topBlock, fillerBlock));
         
         this.setRealisticBiomeName("HL Shrubland");

--- a/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLWoodlands.java
+++ b/src/main/java/rtg/world/biome/realistic/highlands/RealisticBiomeHLWoodlands.java
@@ -22,7 +22,7 @@ public class RealisticBiomeHLWoodlands extends RealisticBiomeHLBase
     
         super(
             hlBiome, BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE),
-            new TerrainHLWoodlands(230f, 120f, 0f),
+            new TerrainHLWoodlands(230f, 40f, 0f),
             new SurfaceHLWoodlands(topBlock, fillerBlock, false, null, 0.95f));
         
         this.setRealisticBiomeName("HL Woodlands");

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
@@ -51,10 +51,10 @@ public class RealisticBiomeVanillaBeach extends RealisticBiomeVanillaBase {
                 int z52 = world.getHeightValue(j6, k10);
                 
                 if (z52 < 80) {
-                    
+                    /*
                     WorldGenerator worldgenerator = new WorldGenTreePalm();
                     worldgenerator.setScale(1.0D, 1.0D, 1.0D);
-                    worldgenerator.generate(world, rand, j6, z52, k10);
+                    worldgenerator.generate(world, rand, j6, z52, k10);*/
                 }
             }
         }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
@@ -51,10 +51,9 @@ public class RealisticBiomeVanillaBeach extends RealisticBiomeVanillaBase {
                 int z52 = world.getHeightValue(j6, k10);
                 
                 if (z52 < 80) {
-                    /*
                     WorldGenerator worldgenerator = new WorldGenTreePalm();
                     worldgenerator.setScale(1.0D, 1.0D, 1.0D);
-                    worldgenerator.generate(world, rand, j6, z52, k10);*/
+                    worldgenerator.generate(world, rand, j6, z52, k10);
                 }
             }
         }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
@@ -36,7 +36,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
             BiomeGenBase.roofedForest,
             BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE),
             new TerrainVanillaRoofedForest(),
-            new SurfaceVanillaRoofedForest(Blocks.grass, Blocks.dirt, false, null, 0f, 1.5f, 60f, 65f, 1.5f, Blocks.stone, 0.15f));
+            new SurfaceVanillaRoofedForest(Blocks.grass, Blocks.dirt, false, null, 0f, 1.5f, 60f, 65f, 1.5f, Blocks.grass, 0.15f));
         
         this.setRealisticBiomeName("Vanilla Roofed Forest");
         this.biomeSize = BiomeSize.NORMAL;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
@@ -36,7 +36,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
             BiomeGenBase.roofedForest,
             BiomeBase.climatizedBiome(BiomeGenBase.river, Climate.TEMPERATE),
             new TerrainVanillaRoofedForest(),
-            new SurfaceVanillaRoofedForest(Blocks.grass, Blocks.dirt, false, null, 0f, 1.5f, 60f, 65f, 1.5f, Blocks.grass, 0.15f));
+            new SurfaceVanillaRoofedForest(Blocks.grass, Blocks.dirt, false, null, 0f, 1.5f, 60f, 65f, 1.5f, Blocks.stone, 0.15f));
         
         this.setRealisticBiomeName("Vanilla Roofed Forest");
         this.biomeSize = BiomeSize.NORMAL;

--- a/src/main/java/rtg/world/gen/surface/highlands/SurfaceHLValley.java
+++ b/src/main/java/rtg/world/gen/surface/highlands/SurfaceHLValley.java
@@ -51,7 +51,7 @@ public class SurfaceHLValley extends SurfaceBase
             	{
             		if(grass && depth < 4)
             		{
-    	        		blocks[(y * 16 + x) * 256 + k] = Blocks.dirt;
+    	        		blocks[(y * 16 + x) * 256 + k] = Blocks.grass;
             		}
             		else if(depth == 0)
             		{
@@ -69,7 +69,7 @@ public class SurfaceHLValley extends SurfaceBase
             	}
         		else if(depth > -1 && depth < 9)
         		{
-        			blocks[(y * 16 + x) * 256 + k] = Blocks.dirt;
+        			blocks[(y * 16 + x) * 256 + k] = Blocks.grass;
         		}
             }
             else if(!water && b == Blocks.water)

--- a/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaBeach.java
+++ b/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaBeach.java
@@ -22,10 +22,10 @@ public class SurfaceVanillaBeach extends SurfaceBase
 	
 	public SurfaceVanillaBeach(Block top, Block filler, Block cliff1, Block cliff2, byte metadata, int cliff)
 	{
-		super(top, filler);
+		super(Blocks.dirt, Blocks.dirt);
 		
-		cliffBlock1 = cliff1;
-		cliffBlock2 = cliff2;
+		cliffBlock1 = Blocks.dirt;
+		cliffBlock2 = Blocks.stone;
 		sandMetadata = metadata;
 		cliffType = cliff;
 	}
@@ -72,9 +72,10 @@ public class SurfaceVanillaBeach extends SurfaceBase
             	}
             	else if(depth < 6)
             	{
-	        		if(depth == 0 && k > 61)
+	        		if(depth == 0 && k > 61 && k < 69)
 	        		{
-	        			if(simplex.noise2(i / 12f, j / 12f) > -0.3f + ((k - 61f) / 15f))
+	        			//if(simplex.noise2(i / 12f, j / 12f) > -0.3f + ((k - 61f) / 15f))
+                        if (false)
 	        			{
 	        				dirt = true;
 		        			blocks[(y * 16 + x) * 256 + k] = topBlock;
@@ -93,13 +94,19 @@ public class SurfaceVanillaBeach extends SurfaceBase
 	        			}
 	        			else
 	        			{
-	        				blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
-		        			metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            if (k > 61 && k < 69) {
+	        				    blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
+		        			    metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            }
 	        			}
 	        		}
 	        		else if(!dirt)
 	        		{
-	        			blocks[(y * 16 + x) * 256 + k] = Blocks.sandstone;
+                        if ( k > 56 && k < 68) { // one lower for under sand and 4 deeper
+	        			    blocks[(y * 16 + x) * 256 + k] = Blocks.sandstone;
+                        } else {
+                            blocks[(y * 16 + x) * 256 + k] = Blocks.stone;
+                        }
 	        		}
             	}
             }

--- a/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaColdBeach.java
+++ b/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaColdBeach.java
@@ -84,8 +84,11 @@ public class SurfaceVanillaColdBeach extends SurfaceBase
                         }
                         else
                         {
-                            blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
-                            metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            if (k<69) {
+                                blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
+                                metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            } // else probably steep shore so leave stone
+
                         }
                     }
                     else if (depth < 4)
@@ -96,8 +99,10 @@ public class SurfaceVanillaColdBeach extends SurfaceBase
                         }
                         else
                         {
-                            blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
-                            metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            if (k<69) {
+                                blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
+                                metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+                            } 
                         }
                     }
                     else if (!dirt)

--- a/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaOcean.java
+++ b/src/main/java/rtg/world/gen/surface/vanilla/SurfaceVanillaOcean.java
@@ -18,6 +18,7 @@ public class SurfaceVanillaOcean extends SurfaceBase
     private float width;
     private float height;
     private float mixCheck;
+    private final int sandMetadata = 0;
     
     public SurfaceVanillaOcean(Block top, Block filler, Block mix, float mixWidth, float mixHeight)
     {
@@ -62,6 +63,12 @@ public class SurfaceVanillaOcean extends SurfaceBase
                 else if (depth < 4 && k < 63)
                 {
                     blocks[(y * 16 + x) * 256 + k] = fillerBlock;
+                }
+
+                else if (depth == 0 && k <69){
+                    blocks[(y * 16 + x) * 256 + k] = Blocks.sand;
+                    metadata[(y * 16 + x) * 256 + k] = sandMetadata;
+
                 }
             }
         }

--- a/src/main/java/rtg/world/gen/terrain/TerrainBase.java
+++ b/src/main/java/rtg/world/gen/terrain/TerrainBase.java
@@ -5,15 +5,28 @@ import rtg.util.OpenSimplexNoise;
 
 public class TerrainBase 
 {
-	public TerrainBase()
-	{
+    protected float base; // added as most terrains have this;
+	public TerrainBase(){
+        this(68f);// default to marginally above sea level;
 	}
+
+    public TerrainBase(float base) {
+        this.base = base;
+    }
 
     public static final float above(float limited, float limit) {
         if (limited>limit) {
             return limited-limit;
         }
         return 0f;
+    }
+
+    public static final float stretched(float toStretch) {
+        if (toStretch > 0) {
+            return (float)Math.sqrt(toStretch);
+        }
+        //(else)
+        return (-1f)*(float)Math.sqrt((-1f)*toStretch);
     }
     
 	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLAutumnForest.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLAutumnForest.java
@@ -30,6 +30,8 @@ public class TerrainHLAutumnForest extends TerrainBase {
             float st = h * 1.5f > 15f ? 15f : h * 1.5f;
             h += cell.noise(x / 70D, y / 70D, 1D) * st;
         }
+
+        h = above(h,10f);
         
         h += simplex.noise2(x / 20f, y / 20f) * 5f;
         h += simplex.noise2(x / 12f, y / 12f) * 3f;

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLBaldHill.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLBaldHill.java
@@ -45,10 +45,11 @@ public class TerrainHLBaldHill extends TerrainBase
     @Override
     public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
     {
-        float h = simplex.noise2(x / vWidth, y / vWidth) * vHeight * river;
+        // add to the simplex noise to increase chance of a hill
+        float h = (simplex.noise2(x / vWidth, y / vWidth)+.5f) * vHeight * river;
         h += simplex.noise2(x / 20f, y / 20f) * 2;
         
-        float m = simplex.noise2(x / hWidth, y / hWidth) * hHeight * river;
+        float m = (simplex.noise2(x / hWidth, y / hWidth)+.5f) * hHeight * river;
         m *= m / 40f;
         
         float sm = simplex.noise2(x / 30f, y / 30f) * 8f;

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLBirchHills.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLBirchHills.java
@@ -40,19 +40,19 @@ public class TerrainHLBirchHills extends TerrainBase
         float h = simplex.noise2(x / 20f, y / 20f) * 2;
         h += simplex.noise2(x / 7f, y / 7f) * 0.8f;
         
-        float m = simplex.noise2(x / width, y / width) * strength * river;
-        m *= m / 35f;
-        m = m > 70f ? 70f + (m - 70f) / 2.5f : m;
+        float m = (simplex.noise2(x / width, y / width)+1) * strength/2 * river;
+        //m *= m / 35f;
+        //m = m > 70f ? 70f + (m - 70f) / 2.5f : m;
         
-        float st = m * 0.7f;
-        st = st > 20f ? 20f : st;
-        float c = cell.noise(x / 30f, y / 30f, 1D) * (5f + st);
+        //float st = m * 0.7f;
+        //st = st > 20f ? 20f : st;
+        //float c = cell.noise(x / 30f, y / 30f, 1D) * (5f + st);
         
         float sm = simplex.noise2(x / 30f, y / 30f) * 8f + simplex.noise2(x / 8f, y / 8f);
-        sm *= (m + 10f) / 20f > 2.5f ? 2.5f : (m + 10f) / 20f;
+        //sm *= (m + 10f) / 20f > 2.5f ? 2.5f : (m + 10f) / 20f;
         m += sm;
-        
-        m += c;
+
+        //m += c;
         
         float l = simplex.noise2(x / lakeWidth, y / lakeWidth) * lakeDepth;
         l *= l / 25f;

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLCliffs.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLCliffs.java
@@ -11,7 +11,7 @@ public class TerrainHLCliffs extends TerrainBase
 	private float lakeDepth;
 	private float lakeWidth;
 	private float terrainHeight;
-    private static float startCliffsAt = 70f;
+    private static float startCliffsAt = 30f;
 
 	/*
 	 * width = 230f
@@ -49,13 +49,14 @@ public class TerrainHLCliffs extends TerrainBase
 		st = st > 20f ? 20f : st;
 		float c = cell.noise(x / 30f, y / 30f, 1D) * (5f + st);
 
-        c = this.above(c, startCliffsAt);
+        //c = this.above(c, startCliffsAt);
 
 		float sm = simplex.noise2(x / 30f, y / 30f) * 8f + simplex.noise2(x / 8f, y / 8f);
 		sm *= (m + 10f) / 20f > 2.5f ? 2.5f : (m + 10f) / 20f;
 		m += sm;
 
 		m += c;
+        m = above(m, startCliffsAt);
 
 		float l = simplex.noise2(x / lakeWidth, y / lakeWidth) * lakeDepth;
 		l *= l / 25f;

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLEstuary.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLEstuary.java
@@ -45,27 +45,18 @@ public class TerrainHLEstuary extends TerrainBase
 	@Override
 	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
 	{
-		float h = simplex.noise2(x / vWidth, y / vWidth) * vHeight * river;
-		h += simplex.noise2(x / 20f, y / 20f) * 2;
-		
-		float m = simplex.noise2(x / hWidth, y / hWidth) * hHeight * river;
-		m *= m / 40f;
-		
-		float sm = simplex.noise2(x / 30f, y / 30f) * 8f;
-		sm *= m / 20f > 3.75f ? 3.75f : m / 20f;
-		m += sm;
-		
-		float cm = cell.noise(x / 25D, y / 25D, 1D) * 12f;
-		cm *= m / 20f > 3.75f ? 3.75f : m / 20f;
-		m += cm;
-		
-		float l = simplex.noise2(x / lWidth, y / lWidth) * lHeight;
-		l *= l / 25f;
-		l = l < 8f ? 8f : l;
-		
-		h += simplex.noise2(x / 12f, y / 12f) * 3f;
-		h += simplex.noise2(x / 5f, y / 5f) * 1.5f;
-		
-		return bHeight + h + m - l;
+		float h = simplex.noise2(x / 130f, y / 130f) * 4f;
+
+		h += simplex.noise2(x / 12f, y / 12f) * 2f;
+		h += simplex.noise2(x / 18f, y / 18f) * 4f;
+
+		h = h < 4f ? 0f : h - 4f;
+
+		if(h == 0f)
+		{
+			h += simplex.noise2(x / 20f, y / 20f) + simplex.noise2(x / 5f, y / 5f);
+		}
+
+		return 62f + h;
 	}
 }

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLFlyingMountains.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLFlyingMountains.java
@@ -22,19 +22,70 @@ public class TerrainHLFlyingMountains extends TerrainBase
 
 	public TerrainHLFlyingMountains(float mountainWidth, float mountainStrength, float depthLake)
 	{
-		this(mountainWidth, mountainStrength, depthLake, 260f, 68f);
+		this(mountainWidth, mountainStrength, depthLake, 260f, 63f);
 	}
 	
 	public TerrainHLFlyingMountains(float mountainWidth, float mountainStrength, float depthLake, float widthLake, float height)
 	{
+        super(height);
 		width = mountainWidth;
-		strength = mountainStrength;
+		strength = mountainStrength*1.3f;
 		lakeDepth = depthLake;
 		lakeWidth = widthLake;
 		terrainHeight = height;
 	}
+
+    //reworked for the soar/plunge effect
+    public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
+	{
+		float h = simplex.noise2(x / 20f, y / 20f) * 2;
+		h += simplex.noise2(x / 7f, y / 7f) * 0.8f;
+
+        // strategy: get 3 separate "mountain" terrains, all mostly water
+        // take the maximum of the 3
+        float adjustment = -0.3f;
+        float simplex1 = stretched(stretched(simplex.noise2(x / width, y / width) - adjustment));
+		float m1 = (simplex1)* strength;
+        m1+=(strength-m1)*simplex.noise2(x / 20f, y / 20f)/4;
+        m1+=(strength-m1)*simplex.noise2(x / 7f, y / 7f)/10;
+
+        float width2 = width*0.7f;
+        float strength2 = strength*0.7f;
+        float simplex2 = stretched(stretched(simplex.noise2(x / width2+0.3f, y / width2+0.3f)- adjustment));
+		float m2 = (simplex2)* strength2;
+        m2+=(strength2-m2)*simplex.noise2(x / 20f, y / 20f)/4;
+        m2+=(strength2-m2)*simplex.noise2(x / 7f, y / 7f)/10;
+
+        float width3 = width*0.5f;
+        float strength3 = strength*0.5f;
+        float simplex3 = stretched(stretched(simplex.noise2(x / width3-0.3f, y / width3-0.3f) - adjustment));
+		float m3 = (simplex3)* strength3;
+        m3+=(strength-m3)*simplex.noise2(x / 20f, y / 20f)/4;
+        m3+=(strength-m3)*simplex.noise2(x / 7f, y / 7f)/10;
+
+        float m = Math.max(m3, Math.max(m1,m2));
+		/*m *= m / 35f;
+		m = m > 70f ? 70f + (m - 70f) / 2.5f : m;
+
+		float st = m * 0.7f;
+		st = st > 20f ? 20f : st;
+		float c = cell.noise(x / 30f, y / 30f, 1D) * (5f + st);
+
+		float sm = simplex.noise2(x / 30f, y / 30f) * 8f + simplex.noise2(x / 8f, y / 8f);
+		sm *= (m + 10f) / 20f > 2.5f ? 2.5f : (m + 10f) / 20f;
+		m += sm;
+
+		m += c;*/
+
+        // no lakes for now
+        float l = 0f;
+		/*float l = simplex.noise2(x / lakeWidth, y / lakeWidth) * lakeDepth;
+		l *= l / 25f;
+		l = l < -8f ? -8f : l;*/
+		return terrainHeight + h + m2 - l;
+	}
 	
-	@Override
+	/*@Override
 	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
 	{
 		float h = simplex.noise2(x / 20f, y / 20f) * 2;
@@ -59,5 +110,5 @@ public class TerrainHLFlyingMountains extends TerrainBase
 		l = l < -8f ? -8f : l;
 		
 		return terrainHeight + h + m - l;
-	}
+	}*/
 }

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLMeadow.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLMeadow.java
@@ -41,8 +41,29 @@ public class TerrainHLMeadow extends TerrainBase
 		
 		bHeight = baseHeight;
 	}
+
+    // copied from vanilla Forest
+    public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
+    {
+
+        float floNoise;
+        float st = (simplex.noise2(x / 160f, y / 160f) + 0.38f) * 10f * river;
+        st = st < 0.2f ? 0.2f : st;
+
+        float h = simplex.noise2(x / 60f, y / 60f) * st * 2f;
+        h = h > 0f ? -h : h;
+        h += st;
+        h *= h / 80f;
+        h += st;
+
+        floNoise = 68f + h;
+
+        // FMLLog.log(Level.INFO, "floNoise = %f", floNoise);
+
+        return floNoise;
+    }
 	
-	@Override
+	/*@Override
 	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
 	{
 		float h = simplex.noise2(x / vWidth, y / vWidth) * vHeight * river;
@@ -67,5 +88,5 @@ public class TerrainHLMeadow extends TerrainBase
 		h += simplex.noise2(x / 5f, y / 5f) * 1.5f;
 		
 		return bHeight + h + m - l;
-	}
+	}*/
 }

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLRainforest.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLRainforest.java
@@ -6,16 +6,57 @@ import rtg.world.gen.terrain.TerrainBase;
 
 public class TerrainHLRainforest extends TerrainBase
 {
-	private float heigth;
 	private float width;
+	private float strength;
+	private float lakeDepth;
+	private float lakeWidth;
+	private float terrainHeight;
+    private static float startCliffsAt = 40f;
 	
-	public TerrainHLRainforest(float mountainHeight, float mountainWidth)
+	public TerrainHLRainforest(float mountainHeight, float mountainWidth, float depthLake)
 	{
-		heigth = mountainHeight;
-		width = mountainWidth;
+		this(mountainWidth, mountainHeight, depthLake, 260f, 78f);
 	}
-	
-	@Override
+
+    public TerrainHLRainforest(float mountainWidth, float mountainStrength, float depthLake, float widthLake, float height)
+	{
+		width = mountainWidth;
+		strength = mountainStrength;
+		lakeDepth = depthLake;
+		lakeWidth = widthLake;
+		terrainHeight = height;
+	}
+		@Override
+	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
+	{
+		float h = simplex.noise2(x / 20f, y / 20f) * 2;
+		h += simplex.noise2(x / 7f, y / 7f) * 0.8f;
+
+		float m = simplex.noise2(x / width, y / width) * strength * river;
+		m *= m / 35f;
+		m = m > 70f ? 70f + (m - 70f) / 2.5f : m;
+
+		float st = m * 0.7f;
+		st = st > 20f ? 20f : st;
+		float c = cell.noise(x / 30f, y / 30f, 1D) * (5f + st);
+
+        //c = this.above(c, startCliffsAt);
+
+		float sm = simplex.noise2(x / 30f, y / 30f) * 8f + simplex.noise2(x / 8f, y / 8f);
+		sm *= (m + 10f) / 20f > 2.5f ? 2.5f : (m + 10f) / 20f;
+		m += sm;
+
+		m += c;
+        m = above(m, startCliffsAt);
+
+		float l = simplex.noise2(x / lakeWidth, y / lakeWidth) * lakeDepth;
+		l *= l / 25f;
+		l = l < -8f ? -8f : l;
+
+		return terrainHeight + h + m - l;
+	}
+
+	/*@Override
 	public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
 	{
 		float h = simplex.noise2(x / width, y / width) * heigth * river;
@@ -54,5 +95,5 @@ public class TerrainHLRainforest extends TerrainBase
 		}
 		
 		return h + 56f;
-	}
+	}*/
 }

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLShrubland.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLShrubland.java
@@ -49,15 +49,16 @@ public class TerrainHLShrubland extends TerrainBase
 		h += simplex.noise2(x / 20f, y / 20f) * 2;
 		
 		float m = simplex.noise2(x / hWidth, y / hWidth) * hHeight * river;
-		m *= m / 40f;
+		//m *= m / 40f;
 		
-		float sm = simplex.noise2(x / 30f, y / 30f) * 8f;
-		sm *= m / 20f > 3.75f ? 3.75f : m / 20f;
+		float sm = simplex.noise2(x / 30f, y / 30f) * 2f;
+		sm *= m / 5f > 3.75f ? 3.75f : m / 20f;
 		m += sm;
 		
-		float cm = cell.noise(x / 25D, y / 25D, 1D) * 12f;
-		cm *= m / 20f > 3.75f ? 3.75f : m / 20f;
+		float cm = cell.noise(x / 25D, y / 25D, 1D) * 4f;
+		cm *= m / 5f > 3.75f ? 3.75f : m / 20f;
 		m += cm;
+        m = above(m,hHeight/2);
 		
 		float l = simplex.noise2(x / lWidth, y / lWidth) * lHeight;
 		l *= l / 25f;

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLSteppe.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLSteppe.java
@@ -13,7 +13,7 @@ public class TerrainHLSteppe extends TerrainBase
 	private float lHeight;
 	private float lWidth;
 	private float bHeight;
-	
+	public static float mountainStart = 30;
 	/*
 	 * hillHeight = 70f
 	 * hillWidth = 180f
@@ -58,6 +58,9 @@ public class TerrainHLSteppe extends TerrainBase
 		float cm = cell.noise(x / 25D, y / 25D, 1D) * 12f;
 		cm *= m / 20f > 3.75f ? 3.75f : m / 20f;
 		m += cm;
+
+        // make mountains less common
+        m = above(m, mountainStart);
 		
 		float l = simplex.noise2(x / lWidth, y / lWidth) * lHeight;
 		l *= l / 25f;
@@ -65,7 +68,8 @@ public class TerrainHLSteppe extends TerrainBase
 		
 		h += simplex.noise2(x / 12f, y / 12f) * 3f;
 		h += simplex.noise2(x / 5f, y / 5f) * 1.5f;
-		
-		return bHeight + h + m - l;
+
+        // no lakes
+		return bHeight + h + m;
 	}
 }

--- a/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLTallPineForest.java
+++ b/src/main/java/rtg/world/gen/terrain/highlands/TerrainHLTallPineForest.java
@@ -5,7 +5,12 @@ import rtg.util.OpenSimplexNoise;
 import rtg.world.gen.terrain.TerrainBase;
 
 public class TerrainHLTallPineForest extends TerrainBase
+
 {
+    public static float hillStrength = 60;
+    public static float hillWidth = 100;
+    public static float hillFloor = 20;
+
 	public TerrainHLTallPineForest()
 	{
 	}
@@ -17,7 +22,11 @@ public class TerrainHLTallPineForest extends TerrainBase
 		float h = cell.noise(x / 200D, y / 200D, 1D) * b * river;
 		h *= h * 1.5f;
 		h = h > 155f ? 155f : h;
-		
+
+        // this creates "hills" which rise abruptly to relatively rounded tops
+        float hill = (simplex.noise2(x / hillWidth, y / hillWidth)*hillStrength);
+        hill = above(hill,hillFloor);
+
 		if(h > 2f)
 		{
 			float d = (h - 2f) / 2f > 8f ? 8f : (h - 2f) / 2f;
@@ -34,6 +43,6 @@ public class TerrainHLTallPineForest extends TerrainBase
 		h += simplex.noise2(x / 18f, y / 18f) * 3;
 		h += simplex.noise2(x / 8f, y / 8f) * 2;
 				
-		return 45f + h + (b * 2);
+		return 45f + h + (b * 2) + hill;
 	}
 }

--- a/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaForest.java
+++ b/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaForest.java
@@ -26,7 +26,7 @@ public class TerrainVanillaForest extends TerrainBase
         h *= h / 80f;
         h += st;
         
-        floNoise = 63f + h;
+        floNoise = 68f + h;
         
         // FMLLog.log(Level.INFO, "floNoise = %f", floNoise);
         

--- a/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaOcean.java
+++ b/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaOcean.java
@@ -23,7 +23,7 @@ public class TerrainVanillaOcean extends TerrainBase
         h += simplex.noise2(x / 50f, y / 50f) * (12f - h) * 0.4f;
         h += simplex.noise2(x / 15f, y / 15f) * (12f - h) * 0.15f;
 
-        float floNoise = 55f + h;
+        float floNoise = 50f + h;
         floNoise = floNoise < 6 ? 6 : floNoise;
 
         return floNoise;

--- a/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaTaiga.java
+++ b/src/main/java/rtg/world/gen/terrain/vanilla/TerrainVanillaTaiga.java
@@ -20,6 +20,6 @@ public class TerrainVanillaTaiga extends TerrainBase
         h += simplex.noise2(x / 50f, y / 50f) * (12f - h) * 0.4f;
         h += simplex.noise2(x / 15f, y / 15f) * (12f - h) * 0.15f;
         
-        return 63f + h;
+        return 68f + h;
     }
 }


### PR DESCRIPTION
Roofed Forest stone patches and Palms on vanilla beaches reverted to prior RTG standing. Changes to beach and ocean left. 

There is a try-catch in WorldChunkManagerRTG that will carry something of a performance penalty but will give an informative crash if an inactive biome is place.