### PR TITLE
Alternate dimension fix and *critical* fix to default worlds.

### DIFF
--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -134,6 +134,8 @@ public class EventManagerRTG
 
     @SubscribeEvent
     public void onBiomeGenInit(WorldTypeEvent.InitBiomeGens event) {
+        // only handle RTG world type
+        if (event.worldType.getWorldTypeName().equalsIgnoreCase("RTG")) return;
         @SuppressWarnings("static-access")
         boolean replace = RTG.instance.configManager(0).rtg().useRTGBiomeGeneration;
         if (replace) {
@@ -150,6 +152,7 @@ public class EventManagerRTG
                 try {
                     event.newBiomeGens = new RiverRemover().riverLess(event.originalBiomeGens);
                 } catch (ClassCastException ex) {
+                    throw ex;
                     // failed attempt because the GenLayers don't end with GenLayerRiverMix
                 }
             }

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -24,7 +24,11 @@ public class WorldTypeRTG extends WorldType
 	@Override
     public WorldChunkManager getChunkManager(World world)
     {
+        if (world.provider.dimensionId == 0) {
         return new WorldChunkManagerRTG(world,this);
+        } else {
+            return new WorldChunkManager(world);
+        }
     }
 
     @Override


### PR DESCRIPTION
Only provides RTG chunk managers to the overworld. Also doesn't do RTG generation changes to non-RTG worlds.