### PR TITLE
Compatibility with biome limit extending mods.

### DIFF
--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -41,7 +41,7 @@ import net.minecraftforge.event.terraingen.TerrainGen;
 
 public class RealisticBiomeBase extends BiomeBase {
     
-    private static final RealisticBiomeBase[] arrRealisticBiomeIds = new RealisticBiomeBase[256];
+    private static final RealisticBiomeBase[] arrRealisticBiomeIds = new RealisticBiomeBase[BiomeGenBase.getBiomeGenArray().length];
     
     public final BiomeGenBase baseBiome;
     public final BiomeGenBase riverBiome;


### PR DESCRIPTION
Biome id limit of 256 can be extended using a lot of asm. But it is possible.
Mods such AIC 2.0 and NEID have done it, so to support them you just have to make your biome array have length of vanilla's.