### PR TITLE
Fix for issue #391, biome 161

### DIFF
--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -78,8 +78,15 @@ public class RealisticBiomeBase extends BiomeBase {
     public RealisticBiomeBase(BiomeGenBase biome, BiomeGenBase river) {
     
         super(biome.biomeID);
-        
-        arrRealisticBiomeIds[biome.biomeID] = this;
+
+    	if (biome.biomeID == 160 && this instanceof rtg.world.biome.realistic.vanilla.RealisticBiomeVanillaRedwoodTaigaHills) {
+
+        	arrRealisticBiomeIds[161] = this;
+
+		} else {
+
+	        arrRealisticBiomeIds[biome.biomeID] = this;
+	    }
                 
         baseBiome = biome;
         riverBiome = river;


### PR DESCRIPTION
Add a work around for Minecraft bug resulting in missing vanilla biome id 161. This fixes issue #391.