### PR TITLE
AIC 2.0 Compatibility

### DIFF
--- a/src/main/java/code/elix_x/coremods/antiidconflict/api/AICChangesWrapper.java
+++ b/src/main/java/code/elix_x/coremods/antiidconflict/api/AICChangesWrapper.java
@@ -1,0 +1,52 @@
+package code.elix_x.coremods.antiidconflict.api;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.ReflectionHelper;
+import net.minecraft.world.chunk.Chunk;
+
+/**
+ * This class wraps all methods that were changed (name or signature) in vanilla by AIC.
+ * Methods here should be used instead of vanilla's, when AIC is loaded, or otherwise your calls to vanilla methods will be redirected and voided to not cause any crashes.
+ * <br>
+ * This part of AIC API can be redistributed freely, but not modified.
+ * @author elix_x
+ */
+public class AICChangesWrapper {
+
+	/**
+	 * Simple method to check if AIC is loaded.
+	 * @return if AIC is loaded or not.
+	 */
+	public static boolean isAICLoaded(){
+		return Loader.isModLoaded("AIC");
+	}
+
+	/**
+	 * Wrapper method to get chunk biomes.
+	 * Use this instead of {@link Chunk#getBiomeArray()}.
+	 * @param chunk {@link Chunk} to get biomes from.
+	 * @return Array of biomes in specified chunk.
+	 */
+	public static int[] getBiomeArray(Chunk chunk){
+		try {
+			return (int[]) ReflectionHelper.findMethod(Chunk.class, chunk, new String[]{"getBiomeArray", "func_76605_m"}).invoke(chunk);
+		} catch (Exception e){
+			return new int[256];
+		}
+	}
+
+	/**
+	 * Wrapper method to set chunk biomes.
+	 * Use this instead of {@link Chunk#setBiomeArray(byte[])}.
+	 * @param chunk {@link Chunk} to set biomes in.
+	 * @param biomes Array of biomes to set in specified chunk.
+	 */
+	public static void setBiomeArray(Chunk chunk, int[] biomes){
+		try {
+			ReflectionHelper.findMethod(Chunk.class, chunk, new String[]{"setBiomeArray", "func_76616_a"}, int[].class).invoke(chunk, biomes);
+		} catch (Exception e){
+
+		}
+	}
+
+}

--- a/src/main/java/code/elix_x/coremods/antiidconflict/api/package-info.java
+++ b/src/main/java/code/elix_x/coremods/antiidconflict/api/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author elix_x
+ */
+@API(owner = "Anti Id Conflict", apiVersion = "2.0", provides = "Anti Id Conflict | API")
+package code.elix_x.coremods.antiidconflict.api;
+
+import cpw.mods.fml.common.API;

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -19,6 +19,7 @@ import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
 import rtg.world.biome.WorldChunkManagerRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
+import code.elix_x.coremods.antiidconflict.api.AICChangesWrapper;
 import cpw.mods.fml.common.eventhandler.Event.Result;
 import cpw.mods.fml.common.registry.GameData;
 
@@ -228,13 +229,23 @@ public class ChunkProviderRTG implements IChunkProvider
         }
 
         Chunk chunk = new Chunk(this.worldObj, blocks, metadata, cx, cy);
-        // doJitter no longer needed as the biome array gets fixed
-        byte[] abyte1 = chunk.getBiomeArray();
-        for (k = 0; k < abyte1.length; ++k)
-        {
-            // biomes are y-first and terrain x-first
-            abyte1[k] = (byte)this.baseBiomesList[this.xyinverted[k]].biomeID;
-        }
+        if(AICChangesWrapper.isAICLoaded()){
+        	int[] biomes = AICChangesWrapper.getBiomeArray(chunk);
+        	for (k = 0; k < biomes.length; ++k)
+        	{
+        		// biomes are z-first and terrain x-first
+        		biomes[k] = this.baseBiomesList[this.xyinverted[k]].biomeID;
+        	}
+        	AICChangesWrapper.setBiomeArray(chunk, biomes);
+        } else {
+        	// doJitter no longer needed as the biome array gets fixed
+        	byte[] abyte1 = chunk.getBiomeArray();
+        	for (k = 0; k < abyte1.length; ++k)
+        	{
+        		// biomes are z-first and terrain x-first
+        		abyte1[k] = (byte)this.baseBiomesList[this.xyinverted[k]].biomeID;
+        	}
+       }
         chunk.generateSkylightMap();
         return chunk;
     }


### PR DESCRIPTION
Added necessary AIC API classes and redirected method calls, if AIC is
installed.
Note: This part of AIC API can be redistributed freely.

AIC 2.0 is the mod i was talikng earlier, which increases biome ids limit.
This is it's API and necesarry changes to be compatible with RTG.
If you want dev version of AIC, or have any questions, contact me over at minecraft forums (i have the same nickname there).

AIC - Anti Id Conflict.