### PR TITLE
AIC 2.0 Compatibility

### DIFF
--- a/src/main/java/code/elix_x/coremods/antiidconflict/api/AICChangesWrapper.java
+++ b/src/main/java/code/elix_x/coremods/antiidconflict/api/AICChangesWrapper.java
@@ -1,0 +1,52 @@
+package code.elix_x.coremods.antiidconflict.api;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.ReflectionHelper;
+import net.minecraft.world.chunk.Chunk;
+
+/**
+ * This class wraps all methods that were changed (name or signature) in vanilla by AIC.
+ * Methods here should be used instead of vanilla's, when AIC is loaded, or otherwise your calls to vanilla methods will be redirected and voided to not cause any crashes.
+ * <br>
+ * This part of AIC API can be redistributed freely, but not modified.
+ * @author elix_x
+ */
+public class AICChangesWrapper {
+
+	/**
+	 * Simple method to check if AIC is loaded.
+	 * @return if AIC is loaded or not.
+	 */
+	public static boolean isAICLoaded(){
+		return Loader.isModLoaded("AIC");
+	}
+
+	/**
+	 * Wrapper method to get chunk biomes.
+	 * Use this instead of {@link Chunk#getBiomeArray()}.
+	 * @param chunk {@link Chunk} to get biomes from.
+	 * @return Array of biomes in specified chunk.
+	 */
+	public static int[] getBiomeArray(Chunk chunk){
+		try {
+			return (int[]) ReflectionHelper.findMethod(Chunk.class, chunk, new String[]{"getBiomeArray", "func_76605_m"}).invoke(chunk);
+		} catch (Exception e){
+			return new int[256];
+		}
+	}
+
+	/**
+	 * Wrapper method to set chunk biomes.
+	 * Use this instead of {@link Chunk#setBiomeArray(byte[])}.
+	 * @param chunk {@link Chunk} to set biomes in.
+	 * @param biomes Array of biomes to set in specified chunk.
+	 */
+	public static void setBiomeArray(Chunk chunk, int[] biomes){
+		try {
+			ReflectionHelper.findMethod(Chunk.class, chunk, new String[]{"setBiomeArray", "func_76616_a"}, int[].class).invoke(chunk, biomes);
+		} catch (Exception e){
+
+		}
+	}
+
+}

--- a/src/main/java/code/elix_x/coremods/antiidconflict/api/package-info.java
+++ b/src/main/java/code/elix_x/coremods/antiidconflict/api/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author elix_x
+ */
+@API(owner = "Anti Id Conflict", apiVersion = "2.0", provides = "Anti Id Conflict | API")
+package code.elix_x.coremods.antiidconflict.api;
+
+import cpw.mods.fml.common.API;

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import code.elix_x.coremods.antiidconflict.api.AICChangesWrapper;
 import rtg.api.biome.BiomeConfig;
 import rtg.config.rtg.ConfigRTG;
 import rtg.util.CanyonColor;
@@ -227,14 +228,25 @@ public class ChunkProviderRTG implements IChunkProvider
         }
 
         Chunk chunk = new Chunk(this.worldObj, blocks, metadata, cx, cy);
-        // doJitter no longer needed as the biome array gets fixed
-        byte[] abyte1 = chunk.getBiomeArray();
-        for (k = 0; k < abyte1.length; ++k)
-        {
-            // biomes are y-first and terrain x-first
-            abyte1[k] = (byte)this.baseBiomesList[this.xyinverted[k]].biomeID;
+        if(AICChangesWrapper.isAICLoaded()){
+        	int[] biomes = AICChangesWrapper.getBiomeArray(chunk);
+        	for (k = 0; k < biomes.length; ++k)
+        	{
+        		// biomes are y-first and terrain x-first
+        		biomes[k] = this.baseBiomesList[this.xyinverted[k]].biomeID;
+        	}
+        	AICChangesWrapper.setBiomeArray(chunk, biomes);
+        } else {
+        	// doJitter no longer needed as the biome array gets fixed
+        	byte[] abyte1 = chunk.getBiomeArray();
+        	for (k = 0; k < abyte1.length; ++k)
+        	{
+        		// biomes are y-first and terrain x-first
+        		byte b = (byte)this.baseBiomesList[this.xyinverted[k]].biomeID;
+        		abyte1[k] = b;
+        	}
+        	chunk.setBiomeArray(abyte1);
         }
-        chunk.setBiomeArray(abyte1);
         chunk.generateSkylightMap();
         return chunk;
     }

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -242,6 +242,12 @@ public class ChunkProviderRTG implements IChunkProvider
         	for (k = 0; k < abyte1.length; ++k)
         	{
         		// biomes are y-first and terrain x-first
+        		/*
+        		* This 2 line separation is needed, because otherwise, AIC's dynamic patching algorith detects vanilla pattern here and patches this part following vanilla logic.
+        		* Which causes game to crash.
+        		* I cannot do much on my part, so i have to do it here.
+        		* - Elix_x
+        		*/
         		byte b = (byte)this.baseBiomesList[this.xyinverted[k]].biomeID;
         		abyte1[k] = b;
         	}


### PR DESCRIPTION
These are all the methods that have to be modified to make RTG and AIC
fully compatible.
Note: this part of AIC API can be redistributed freely.

AIC 2.0 is the mod i was talikng earlier, which increases biome ids limit.
This is it's API and necesarry changes to be compatible with RTG.
If you want dev version of AIC, or have any questions, contact me over at minecraft forums (i am [elix_x ](http://www.minecraftforum.net/members/elix_x)over there).

AIC - Anti Id Conflict.

This is 2nd try of me pull requesting. Now i updated my fork, and targeted dev (as you asked).
Also, this part of AIC API can be redistributed and does not contain any big and complex methods and consists of 1 class.