### PR TITLE
Updated river generation & other noise updates

### DIFF
--- a/src/main/java/rtg/util/SimplexCellularNoise.java
+++ b/src/main/java/rtg/util/SimplexCellularNoise.java
@@ -1,0 +1,204 @@
+package rtg.util;
+
+/**
+ * @author KdotJPG
+ * 
+ * Generates 2D Simplex-cellular noise.
+ * 
+ * Simplex-cellular noise is cellular noise implemented using the lattice
+ * of Simplex noise.
+ * 
+ * In this case the point contribution determination is implemented using
+ * a lookup scheme inspired by DigitalShadow's optimized implementation of
+ * OpenSimplex noise, and a permutation table of size 1024 is used instead
+ * of the traditional 256.
+ * 
+ * Each point set is defined as the directions from the center to the
+ * vertices of the normalized expanded vertex figure of the lattice for
+ * the given dimensionality. These point sets are symmetric with the
+ * lattice, but don't include directions that follow edges or facets.
+ * 
+ * Supports multi-evaluation with F1 and F2 values.
+ * 
+ * Version 02/05/2015
+ */
+
+public class SimplexCellularNoise {
+
+	private short[] perm;
+	private short[] perm2D;
+
+	public SimplexCellularNoise(long seed) {
+		perm = new short[1024];
+		perm2D = new short[1024];
+		short[] source = new short[1024]; 
+		for (short i = 0; i < 1024; i++)
+			source[i] = i;
+		for (int i = 1023; i >= 0; i--) {
+			seed = seed * 6364136223846793005L + 1442695040888963407L;
+			int r = (int)((seed + 31) % (i + 1));
+			if (r < 0)
+				r += (i + 1);
+			perm[i] = source[r];
+			perm2D[i] = (short)((perm[i] % 12) * 2);
+			source[r] = source[i];
+		}
+	}
+	
+	/*
+	 * 2D multi-instance evaluation function
+	 */
+	
+	//2D Simplex-Cellular noise (Multi-eval)
+	public static void eval(double x, double y, NoiseInstance2[] instances, double[] results) {
+		
+		//Get points for A2* lattice
+		double s = 0.366025403784439 * (x + y);
+		double xs = x + s, ys = y + s;
+		
+		//Get base points and offsets
+		int xsb = fastFloor(xs), ysb = fastFloor(ys);
+		double xsi = xs - xsb, ysi = ys - ysb;
+		
+		//Index to point list
+		int index =
+			((int)(xsi + ysi) * 9) +
+			((int)(xsi * 2 - ysi + 1) * 9 * 2) +
+			((int)(ysi * 2 - xsi + 1) * 9 * 6);
+		
+		//Offsets in input space
+		double ssi = (xsi + ysi) * -0.211324865405187;
+		double xi = xsi + ssi, yi = ysi + ssi;
+
+		//Point contributions
+		for (int i = 0; i < 9; i++) {
+			LatticePoint2D c = LOOKUP_2D[index + i];
+
+			int pxm = (xsb + c.xsv) & 1023, pym = (ysb + c.ysv) & 1023;
+			for (NoiseInstance2 instance : instances) {
+				int ji = instance.noise.perm2D[instance.noise.perm[pxm] ^ pym];
+				double jx = JITTER_2D[ji + 0], jy = JITTER_2D[ji + 1];
+				double djx = jx - (c.dx + xi),
+						djy = jy - (c.dy + yi);
+				double distance = Math.sqrt(djx * djx + djy * djy);
+				
+				if (instance.f2Index >= 0) {
+					if (distance < results[instance.f2Index]) {
+						results[instance.f2Index] = distance;
+						if (distance < results[instance.f1Index]) {
+							results[instance.f2Index] = results[instance.f1Index];
+							results[instance.f1Index] = distance;
+						}
+					}
+				} else if (instance.f1Index >= 0) {
+					if (distance < results[instance.f1Index]) {
+						results[instance.f1Index] = distance;
+					}
+				}
+			}
+		}
+	}
+	
+	/*
+	 * Init functions
+	 */
+	
+	public static double[] initResultArray(NoiseInstance2[] instances) {
+		int max = 0;
+		for (NoiseInstance2 instance : instances) {
+			if (instance.f1Index > max) max = instance.f1Index;
+			if (instance.f2Index > max) max = instance.f2Index;
+		}
+		double[] destination = new double[max + 1];
+		return destination;
+	}
+	
+	public static void resetResultArray(NoiseInstance2[] instances, double[] results) {
+		for (NoiseInstance2 instance : instances) {
+			if (instance.f1Index >= 0) {
+				results[instance.f1Index] = Double.POSITIVE_INFINITY;
+			}
+			if (instance.f2Index >= 0) {
+				results[instance.f2Index] = Double.POSITIVE_INFINITY;
+			}
+		}
+	}
+	
+	/*
+	 * Utility
+	 */
+	
+	private static int fastFloor(double x) {
+		int xi = (int)x;
+		return x < xi ? xi - 1 : xi;
+	}
+	
+	/*
+	 * Definitions
+	 */
+
+	private static final LatticePoint2D[] LOOKUP_2D;
+	static {
+		LOOKUP_2D = new LatticePoint2D[18 * 9];
+		
+		for (int i = 0; i < 18; i++) {
+			int i1, j1, i2, j2, i3, j3, i4, j4, i5, j5;
+			int a = (i & 1);
+			int b = (i / 2) % 3;
+			int c = (i / 6) % 3;
+			if (a == 0) { i1 = -1; j1 = -1; } else { i1 = 2; j1 = 2; }
+			if (b < 2) { i2 = -1; j2 = 0; } else { i2 = 2; j2 = 0; }
+			if (b < 1) { i3 = -1; j3 = 1; } else { i3 = 2; j3 = 1; }
+			if (c < 2) { i4 = 0; j4 = -1; } else { i4 = 0; j4 = 2; }
+			if (c < 1) { i5 = 1; j5 = -1; } else { i5 = 1; j5 = 2; }
+			LOOKUP_2D[i * 9 + 0] = new LatticePoint2D(0, 0);
+			LOOKUP_2D[i * 9 + 1] = new LatticePoint2D(1, 0);
+			LOOKUP_2D[i * 9 + 2] = new LatticePoint2D(0, 1);
+			LOOKUP_2D[i * 9 + 3] = new LatticePoint2D(1, 1);
+			LOOKUP_2D[i * 9 + 4] = new LatticePoint2D(i1, j1);
+			LOOKUP_2D[i * 9 + 5] = new LatticePoint2D(i2, j2);
+			LOOKUP_2D[i * 9 + 6] = new LatticePoint2D(i3, j3);
+			LOOKUP_2D[i * 9 + 7] = new LatticePoint2D(i4, j4);
+			LOOKUP_2D[i * 9 + 8] = new LatticePoint2D(i5, j5);
+		}
+	}
+	
+	//2D Points: Dodecagon
+	private static final double[] JITTER_2D = new double[] {
+		                 0,		 0.408248290463863,
+		 0.204124145231932,		 0.353553390593274,
+		 0.353553390593274,		 0.204124145231932,
+		 0.408248290463863,		                 0,
+		 0.353553390593274,		-0.204124145231932,
+		 0.204124145231932,		-0.353553390593274,
+		                 0,		-0.408248290463863,
+		-0.204124145231932,		-0.353553390593274,
+		-0.353553390593274,		-0.204124145231932,
+		-0.408248290463863,		                 0,
+		-0.353553390593274,		 0.204124145231932,
+		-0.204124145231932,		 0.353553390593274
+	};
+	
+	private static class LatticePoint2D {
+		public int xsv, ysv;
+		public double dx, dy;
+		public LatticePoint2D(int xsv, int ysv) {
+			this.xsv = xsv; this.ysv = ysv;
+			double ssv = (xsv + ysv) * -0.211324865405187;
+			this.dx = -xsv - ssv;
+			this.dy = -ysv - ssv;
+		}
+	}
+	
+	public static class NoiseInstance2 {
+		public NoiseInstance2(SimplexCellularNoise noise, int f1Index,
+				int f2Index) {
+			this.noise = noise;
+			this.f1Index = f1Index;
+			this.f2Index = f2Index;
+		}
+		public SimplexCellularNoise noise;
+		public int f1Index;
+		public int f2Index;
+	}
+}

--- a/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
+++ b/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Level;
 
 import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
+import rtg.util.SimplexCellularNoise;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import cpw.mods.fml.common.FMLLog;
 
@@ -30,6 +31,9 @@ public class WorldChunkManagerRTG extends WorldChunkManager implements RTGBiomeP
     private List biomesToSpawnIn;
     private OpenSimplexNoise simplex;
     private CellNoise cell;
+    private SimplexCellularNoise simplexCell;
+    private SimplexCellularNoise.NoiseInstance2[] riverCellNoiseInstances;
+    private OpenSimplexNoise.NoiseInstance2[] riverOpenSimplexNoiseInstances;
     private float[] borderNoise;
     private TLongObjectHashMap<RealisticBiomeBase> biomeDataMap = new TLongObjectHashMap<RealisticBiomeBase>();
     private BiomeCache biomeCache;
@@ -52,6 +56,13 @@ public class WorldChunkManagerRTG extends WorldChunkManager implements RTGBiomeP
         simplex = new OpenSimplexNoise(seed);
         cell = new CellNoise(seed, (short) 0);
         cell.setUseDistance(true);
+        simplexCell = new SimplexCellularNoise(seed);
+        riverCellNoiseInstances = new SimplexCellularNoise.NoiseInstance2[] {
+        		new SimplexCellularNoise.NoiseInstance2(simplexCell, 0, 1)
+        };
+        riverOpenSimplexNoiseInstances = new OpenSimplexNoise.NoiseInstance2[] {
+        		new OpenSimplexNoise.NoiseInstance2(simplex, -1, -1, -1, 0, 1)
+        };
         GenLayer[] agenlayer = GenLayer.initializeAllBiomeGenerators(seed, worldType);
         agenlayer = getModdedBiomeGenerators(worldType, seed, agenlayer);
         this.genBiomes = agenlayer[0]; //maybe this will be needed
@@ -196,14 +207,33 @@ public class WorldChunkManagerRTG extends WorldChunkManager implements RTGBiomeP
         return getBiomeDataAt(x, y).rNoise(simplex, cell, x, y, 1f, river);
     }
     
+	private static double cellBorder(double[] results, double width, double depth) {
+		double c = results[1] - results[0];
+		if (c < width) {
+			return ((c / width) - 1) * depth;
+		} else {
+			return 0;
+		}
+	}
+    
     public float calculateRiver(int x, int y, float st, float biomeHeight)
     {
         
         if (st < 0f && biomeHeight > 59f)
         {
-            float pX = x + (simplex.noise1(y / 240f) * 220f);
-            float pY = y + (simplex.noise1(x / 240f) * 220f);
-            float r = cell.border(pX / 1250D, pY / 1250D, 50D / 1300D, 1f);
+        	//New river curve function. No longer creates worldwide curve correlations along cardinal axes.
+        	double[] simplexResults = new double[2];
+        	OpenSimplexNoise.noise(x / 240f, y / 240f, riverOpenSimplexNoiseInstances, simplexResults);
+            double pX = x + simplexResults[0] * 220f;
+            double pY = y + simplexResults[1] * 220f;
+
+            //New cellular noise.
+            //TODO move the initialization of the results in a way that's more efficient but still thread safe.
+            double[] results = SimplexCellularNoise.initResultArray(riverCellNoiseInstances);
+            SimplexCellularNoise.resetResultArray(riverCellNoiseInstances, results);
+            SimplexCellularNoise.eval(pX / 3125.0, pY / 3125.0, riverCellNoiseInstances, results);
+            float r = (float) cellBorder(results, 30.0 / 1300.0, 1.0);
+            
             return (biomeHeight * (r + 1f))
                 + ((59f + simplex.noise2(x / 12f, y / 12f) * 2f + simplex.noise2(x / 8f, y / 8f) * 1.5f) * (-r));
         }
@@ -212,14 +242,23 @@ public class WorldChunkManagerRTG extends WorldChunkManager implements RTGBiomeP
             return biomeHeight;
         }
     }
-    
+
     public float getRiverStrength(int x, int y)
     {
+    	//New river curve function. No longer creates worldwide curve correlations along cardinal axes.
+    	double[] simplexResults = new double[2];
+    	OpenSimplexNoise.noise(x / 240f, y / 240f, riverOpenSimplexNoiseInstances, simplexResults);
+        double pX = x + simplexResults[0] * 220f;
+        double pY = y + simplexResults[1] * 220f;
         
-        return cell
-            .border((x + (simplex.noise1(y / 240f) * 220f)) / 1250D, (y + (simplex.noise1(x / 240f) * 220f)) / 1250D, 50D / 300D, 1f);
+        //New cellular noise.
+        //TODO move the initialization of the results in a way that's more efficient but still thread safe.
+        double[] results = SimplexCellularNoise.initResultArray(riverCellNoiseInstances);
+        SimplexCellularNoise.resetResultArray(riverCellNoiseInstances, results);
+        SimplexCellularNoise.eval(pX / 3125.0, pY / 3125.0, riverCellNoiseInstances, results);
+        return (float) cellBorder(results, 30.0 / 300.0, 1.0);
     }
-    
+    	
     public boolean isBorderlessAt(int x, int y)
     {
         


### PR DESCRIPTION
Rivers now use a faster and *slightly* less square cell noise function (Simplex-Cellular noise)
OpenSimplex noise 3D gradient set updated.
OpenSimplex noise 2D replaced with lookup-table version.
OpenSimplex noise 2D multi-eval function added, with support for simultaneous evaluation of the same point with different seeds, first derivatives, and "disc-output" noise (which is noise that outputs a 2D coordinate on a unit disc rather than a 1D coordinate between -1 and 1)
River curvature now uses "disc-output" noise rather than two one-dimensional functions.

Issue #399, while not the main focus of this PR, is resolved by it.

EDIT: I should also add that it is uncertain whether or not this resolves the "sine-wave fault line" in issue #467.