### PR TITLE
Biome-specific cave settings.

### DIFF
--- a/etc/config/RTG/biomes/abyssalcraft.cfg
+++ b/etc/config/RTG/biomes/abyssalcraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -76,6 +82,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -119,6 +131,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -167,6 +185,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -202,6 +226,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -236,6 +266,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/abyssalcraft.cfg
+++ b/etc/config/RTG/biomes/abyssalcraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         darklands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -63,6 +87,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -94,6 +130,18 @@ biome {
         darklandshighland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -130,6 +178,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -152,6 +212,18 @@ biome {
         darklandsplains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/arsmagica.cfg
+++ b/etc/config/RTG/biomes/arsmagica.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 

--- a/etc/config/RTG/biomes/arsmagica.cfg
+++ b/etc/config/RTG/biomes/arsmagica.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 

--- a/etc/config/RTG/biomes/atg.cfg
+++ b/etc/config/RTG/biomes/atg.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         rockysteppe {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -54,6 +78,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -76,6 +112,18 @@ biome {
         snowygravelbeach {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -100,6 +148,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -122,6 +182,18 @@ biome {
         tundra {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -146,6 +218,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -168,6 +252,18 @@ biome {
         woodland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/atg.cfg
+++ b/etc/config/RTG/biomes/atg.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -102,6 +114,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -136,6 +154,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -172,6 +196,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -206,6 +236,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -242,6 +278,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -276,6 +318,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/biomesoplenty.cfg
+++ b/etc/config/RTG/biomes/biomesoplenty.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         alpsforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -57,6 +81,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -79,6 +115,18 @@ biome {
         bambooforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -103,6 +151,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -125,6 +185,18 @@ biome {
         bog {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -149,6 +221,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -171,6 +255,18 @@ biome {
         brushland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -195,6 +291,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -217,6 +325,18 @@ biome {
         canyonravine {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -241,6 +361,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -263,6 +395,18 @@ biome {
         cherryblossomgrove {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -290,6 +434,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -316,6 +472,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -339,6 +507,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -361,6 +541,18 @@ biome {
         deadforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -388,6 +580,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -410,6 +614,18 @@ biome {
         deciduousforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -437,6 +653,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -463,6 +691,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -485,6 +725,18 @@ biome {
         eucalyptusforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -512,6 +764,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -538,6 +802,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -560,6 +836,18 @@ biome {
         frostforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -587,6 +875,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -613,6 +913,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -635,6 +947,18 @@ biome {
         glacier {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -659,6 +983,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -681,6 +1017,18 @@ biome {
         grove {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -708,6 +1056,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -734,6 +1094,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -756,6 +1128,18 @@ biome {
         jadecliffs {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -783,6 +1167,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -805,6 +1201,18 @@ biome {
         landoflakes {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -832,6 +1240,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -855,6 +1275,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -877,6 +1309,18 @@ biome {
         lushdesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -904,6 +1348,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -926,6 +1382,18 @@ biome {
         lushswamp {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -953,6 +1421,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -975,6 +1455,18 @@ biome {
         maplewoods {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1002,6 +1494,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1024,6 +1528,18 @@ biome {
         meadow {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1048,6 +1564,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1071,6 +1599,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1093,6 +1633,18 @@ biome {
         mountain {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1120,6 +1672,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1145,6 +1709,18 @@ biome {
         oasis {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1172,6 +1748,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1197,6 +1785,18 @@ biome {
         orchard {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1224,6 +1824,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1246,6 +1858,18 @@ biome {
         outback {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1270,6 +1894,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1292,6 +1928,18 @@ biome {
         quagmire {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1316,6 +1964,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1338,6 +1998,18 @@ biome {
         redwoodforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1365,6 +2037,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1388,6 +2072,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1410,6 +2106,18 @@ biome {
         seasonalforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1437,6 +2145,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1462,6 +2182,18 @@ biome {
         shield {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1489,6 +2221,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1511,6 +2255,18 @@ biome {
         silkglades {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1535,6 +2291,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1557,6 +2325,18 @@ biome {
         snowyconiferousforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1584,6 +2364,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1610,6 +2402,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1632,6 +2436,18 @@ biome {
         temperaterainforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1656,6 +2472,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1679,6 +2507,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1701,6 +2541,18 @@ biome {
         tropics {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1728,6 +2580,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1750,6 +2614,18 @@ biome {
         volcano {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1774,6 +2650,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1796,6 +2684,18 @@ biome {
         wetland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1820,6 +2720,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1842,6 +2754,18 @@ biome {
         xericshrubland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/biomesoplenty.cfg
+++ b/etc/config/RTG/biomes/biomesoplenty.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -70,6 +76,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -104,6 +116,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -140,6 +158,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -174,6 +198,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -210,6 +240,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -244,6 +280,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -280,6 +322,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -314,6 +362,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -350,6 +404,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -384,6 +444,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -423,6 +489,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -461,6 +533,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -496,6 +574,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -530,6 +614,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -569,6 +659,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -603,6 +699,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -642,6 +744,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -680,6 +788,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -714,6 +828,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -753,6 +873,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -791,6 +917,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -825,6 +957,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -864,6 +1002,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -902,6 +1046,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -936,6 +1086,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -972,6 +1128,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1006,6 +1168,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1045,6 +1213,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1083,6 +1257,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1117,6 +1297,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1156,6 +1342,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1190,6 +1382,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1229,6 +1427,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1264,6 +1468,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1298,6 +1508,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1337,6 +1553,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1371,6 +1593,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1410,6 +1638,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1444,6 +1678,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1483,6 +1723,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1517,6 +1763,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1553,6 +1805,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1588,6 +1846,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1622,6 +1886,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1661,6 +1931,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1698,6 +1974,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1737,6 +2019,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1774,6 +2062,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1813,6 +2107,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1847,6 +2147,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1883,6 +2189,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1917,6 +2229,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1953,6 +2271,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1987,6 +2311,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2026,6 +2356,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2061,6 +2397,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2095,6 +2437,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2134,6 +2482,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2171,6 +2525,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2210,6 +2570,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2244,6 +2610,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2280,6 +2652,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2314,6 +2692,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2353,6 +2737,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2391,6 +2781,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2425,6 +2821,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2461,6 +2863,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2496,6 +2904,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2530,6 +2944,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2569,6 +2989,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2603,6 +3029,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2639,6 +3071,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2673,6 +3111,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2709,6 +3153,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2744,6 +3194,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2778,6 +3234,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/buildcraft.cfg
+++ b/etc/config/RTG/biomes/buildcraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         oceanoilfield {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/buildcraft.cfg
+++ b/etc/config/RTG/biomes/buildcraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/chromaticraft.cfg
+++ b/etc/config/RTG/biomes/chromaticraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/chromaticraft.cfg
+++ b/etc/config/RTG/biomes/chromaticraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         rainbowforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/enhancedbiomes.cfg
+++ b/etc/config/RTG/biomes/enhancedbiomes.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -102,6 +114,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -136,6 +154,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -172,6 +196,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -206,6 +236,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -242,6 +278,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -276,6 +318,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -315,6 +363,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -353,6 +407,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -387,6 +447,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -423,6 +489,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -458,6 +530,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -492,6 +570,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -531,6 +615,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -565,6 +655,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -601,6 +697,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -635,6 +737,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -671,6 +779,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -705,6 +819,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -741,6 +861,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -775,6 +901,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -811,6 +943,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -845,6 +983,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -884,6 +1028,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -922,6 +1072,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -956,6 +1112,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -992,6 +1154,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1027,6 +1195,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1061,6 +1235,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1100,6 +1280,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1138,6 +1324,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1172,6 +1364,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1208,6 +1406,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1242,6 +1446,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1278,6 +1488,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1312,6 +1528,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1348,6 +1570,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1382,6 +1610,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1421,6 +1655,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1455,6 +1695,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1491,6 +1737,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1525,6 +1777,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1561,6 +1819,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1595,6 +1859,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1631,6 +1901,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1665,6 +1941,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1701,6 +1983,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1735,6 +2023,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1771,6 +2065,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1805,6 +2105,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1841,6 +2147,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1875,6 +2187,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1911,6 +2229,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1945,6 +2269,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1981,6 +2311,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2015,6 +2351,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2051,6 +2393,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2085,6 +2433,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2121,6 +2475,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2155,6 +2515,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2194,6 +2560,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2231,6 +2603,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2270,6 +2648,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2307,6 +2691,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2346,6 +2736,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2380,6 +2776,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2416,6 +2818,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2450,6 +2858,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2486,6 +2900,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2520,6 +2940,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2556,6 +2982,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2590,6 +3022,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2626,6 +3064,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2661,6 +3105,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2695,6 +3145,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2734,6 +3190,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2772,6 +3234,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2806,6 +3274,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2842,6 +3316,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2876,6 +3356,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2912,6 +3398,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2946,6 +3438,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2982,6 +3480,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -3016,6 +3520,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -3052,6 +3562,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -3086,6 +3602,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -3122,6 +3644,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -3157,6 +3685,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -3191,6 +3725,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/enhancedbiomes.cfg
+++ b/etc/config/RTG/biomes/enhancedbiomes.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         alpinemountainsedge {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -54,6 +78,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -76,6 +112,18 @@ biome {
         alpinetundra {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -100,6 +148,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -122,6 +182,18 @@ biome {
         aspenhills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -146,6 +218,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -169,6 +253,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -191,6 +287,18 @@ biome {
         blossomhills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -218,6 +326,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -244,6 +364,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -266,6 +398,18 @@ biome {
         borealforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -290,6 +434,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -313,6 +469,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -335,6 +503,18 @@ biome {
         carr {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -362,6 +542,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -384,6 +576,18 @@ biome {
         clearing {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -408,6 +612,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -430,6 +646,18 @@ biome {
         coldcypressforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -454,6 +682,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -476,6 +716,18 @@ biome {
         coldpineforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -500,6 +752,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -522,6 +786,18 @@ biome {
         cypressforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -546,6 +822,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -568,6 +856,18 @@ biome {
         ephemerallake {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -595,6 +895,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -621,6 +933,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -643,6 +967,18 @@ biome {
         firforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -667,6 +1003,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -690,6 +1038,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -712,6 +1072,18 @@ biome {
         forestedmountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -739,6 +1111,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -765,6 +1149,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -787,6 +1183,18 @@ biome {
         glacier {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -811,6 +1219,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -833,6 +1253,18 @@ biome {
         icesheet {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -857,6 +1289,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -879,6 +1323,18 @@ biome {
         lake {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -903,6 +1359,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -925,6 +1393,18 @@ biome {
         mangroves {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -952,6 +1432,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -974,6 +1466,18 @@ biome {
         meadow {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -998,6 +1502,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1020,6 +1536,18 @@ biome {
         mountainousarchipelago {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1044,6 +1572,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1066,6 +1606,18 @@ biome {
         mountainsedge {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1090,6 +1642,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1112,6 +1676,18 @@ biome {
         oasis {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1136,6 +1712,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1158,6 +1746,18 @@ biome {
         pineforestarchipelago {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1182,6 +1782,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1204,6 +1816,18 @@ biome {
         polardesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1228,6 +1852,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1250,6 +1886,18 @@ biome {
         rainforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1274,6 +1922,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1296,6 +1956,18 @@ biome {
         reddesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1320,6 +1992,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1342,6 +2026,18 @@ biome {
         rockydesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1366,6 +2062,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1388,6 +2096,18 @@ biome {
         roofedshrublands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1412,6 +2132,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1434,6 +2166,18 @@ biome {
         sandstonecanyon {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1461,6 +2205,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1486,6 +2242,18 @@ biome {
         sandstoneranges {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1513,6 +2281,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1538,6 +2318,18 @@ biome {
         scree {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1565,6 +2357,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1587,6 +2391,18 @@ biome {
         shield {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1611,6 +2427,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1633,6 +2461,18 @@ biome {
         silverpineforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1657,6 +2497,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1679,6 +2531,18 @@ biome {
         snowydesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1703,6 +2567,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1725,6 +2601,18 @@ biome {
         snowyranges {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1749,6 +2637,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1772,6 +2672,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1794,6 +2706,18 @@ biome {
         stonecanyon {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1821,6 +2745,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1847,6 +2783,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1869,6 +2817,18 @@ biome {
         tundra {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1893,6 +2853,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1915,6 +2887,18 @@ biome {
         volcanom {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1939,6 +2923,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1961,6 +2957,18 @@ biome {
         woodlandfield {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1985,6 +2993,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -2007,6 +3027,18 @@ biome {
         woodlandlake {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -2031,6 +3063,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -2053,6 +3097,18 @@ biome {
         woodlands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -2077,6 +3133,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -2099,6 +3167,18 @@ biome {
         xericshrubland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/extrabiomes.cfg
+++ b/etc/config/RTG/biomes/extrabiomes.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -70,6 +76,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -104,6 +116,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -140,6 +158,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -174,6 +198,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -210,6 +240,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -244,6 +280,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -280,6 +322,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -314,6 +362,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -350,6 +404,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -384,6 +444,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -420,6 +486,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -454,6 +526,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -490,6 +568,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -524,6 +608,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -560,6 +650,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -595,6 +691,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -629,6 +731,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -668,6 +776,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -706,6 +820,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -740,6 +860,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -776,6 +902,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -810,6 +942,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -846,6 +984,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -880,6 +1024,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -916,6 +1066,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -951,6 +1107,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -985,6 +1147,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/extrabiomes.cfg
+++ b/etc/config/RTG/biomes/extrabiomes.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         autumnwoods {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -57,6 +81,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -79,6 +115,18 @@ biome {
         extremejungle {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -103,6 +151,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -125,6 +185,18 @@ biome {
         forestedisland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -149,6 +221,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -171,6 +255,18 @@ biome {
         greenhills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -195,6 +291,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -217,6 +325,18 @@ biome {
         icewasteland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -241,6 +361,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -263,6 +395,18 @@ biome {
         meadow {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -287,6 +431,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -309,6 +465,18 @@ biome {
         mountaindesert {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -333,6 +501,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -355,6 +535,18 @@ biome {
         mountaintaiga {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -379,6 +571,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -402,6 +606,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -424,6 +640,18 @@ biome {
         redwoodforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -451,6 +679,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -477,6 +717,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -499,6 +751,18 @@ biome {
         shrubland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -523,6 +787,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -545,6 +821,18 @@ biome {
         snowyrainforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -569,6 +857,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -591,6 +891,18 @@ biome {
         tundra {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -615,6 +927,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -637,6 +961,18 @@ biome {
         woodlands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/forgottennature.cfg
+++ b/etc/config/RTG/biomes/forgottennature.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         crystalforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -54,6 +78,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -76,6 +112,18 @@ biome {
         greatwoodforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -100,6 +148,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -122,6 +182,18 @@ biome {
         redwoodforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -146,6 +218,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -169,6 +253,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -191,6 +287,18 @@ biome {
         tropicalforesthills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/forgottennature.cfg
+++ b/etc/config/RTG/biomes/forgottennature.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -102,6 +114,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -136,6 +154,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -172,6 +196,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -206,6 +236,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -242,6 +278,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -277,6 +319,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -311,6 +359,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/growthcraft.cfg
+++ b/etc/config/RTG/biomes/growthcraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 

--- a/etc/config/RTG/biomes/growthcraft.cfg
+++ b/etc/config/RTG/biomes/growthcraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 

--- a/etc/config/RTG/biomes/highlands.cfg
+++ b/etc/config/RTG/biomes/highlands.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -102,6 +114,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -136,6 +154,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -172,6 +196,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -206,6 +236,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -242,6 +278,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -276,6 +318,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -312,6 +360,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -346,6 +400,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -382,6 +442,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -416,6 +482,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -455,6 +527,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -489,6 +567,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -525,6 +609,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -559,6 +649,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -595,6 +691,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -629,6 +731,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -665,6 +773,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -699,6 +813,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -735,6 +855,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -769,6 +895,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -805,6 +937,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -839,6 +977,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -875,6 +1019,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -910,6 +1060,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -944,6 +1100,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -983,6 +1145,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1017,6 +1185,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1053,6 +1227,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1087,6 +1267,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1123,6 +1309,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1157,6 +1349,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1193,6 +1391,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1227,6 +1431,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1263,6 +1473,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1297,6 +1513,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1333,6 +1555,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1367,6 +1595,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1403,6 +1637,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1437,6 +1677,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1473,6 +1719,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1507,6 +1759,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/highlands.cfg
+++ b/etc/config/RTG/biomes/highlands.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         autumnforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -54,6 +78,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -76,6 +112,18 @@ biome {
         baldhill {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -100,6 +148,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -122,6 +182,18 @@ biome {
         bog {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -146,6 +218,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -168,6 +252,18 @@ biome {
         cliffs {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -192,6 +288,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -214,6 +322,18 @@ biome {
         desertmountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -238,6 +358,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -261,6 +393,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -283,6 +427,18 @@ biome {
         flyingmountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -310,6 +466,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -332,6 +500,18 @@ biome {
         glacier {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -356,6 +536,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -378,6 +570,18 @@ biome {
         jungleisland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -402,6 +606,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -424,6 +640,18 @@ biome {
         lowlands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -448,6 +676,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -470,6 +710,18 @@ biome {
         mesa {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -494,6 +746,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -516,6 +780,18 @@ biome {
         outback {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -540,6 +816,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -562,6 +850,18 @@ biome {
         rainforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -586,6 +886,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -609,6 +921,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -631,6 +955,18 @@ biome {
         rockmountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -658,6 +994,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -680,6 +1028,18 @@ biome {
         savannah {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -704,6 +1064,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -726,6 +1098,18 @@ biome {
         snowisland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -750,6 +1134,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -772,6 +1168,18 @@ biome {
         steppe {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -796,6 +1204,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -818,6 +1238,18 @@ biome {
         tropicalislands {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -842,6 +1274,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -864,6 +1308,18 @@ biome {
         tundra {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -888,6 +1344,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -910,6 +1378,18 @@ biome {
         volcanoisland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -934,6 +1414,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -957,6 +1449,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -979,6 +1483,18 @@ biome {
         woodsmountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/ridiculousworld.cfg
+++ b/etc/config/RTG/biomes/ridiculousworld.cfg
@@ -41,6 +41,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -75,6 +81,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -111,6 +123,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -145,6 +163,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -181,6 +205,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -216,6 +246,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -250,6 +286,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/ridiculousworld.cfg
+++ b/etc/config/RTG/biomes/ridiculousworld.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -40,6 +52,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -62,6 +86,18 @@ biome {
         mountainofmadness {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -86,6 +122,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -108,6 +156,18 @@ biome {
         rockcandymountain {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -132,6 +192,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -154,6 +226,18 @@ biome {
         spookyforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/thaumcraft.cfg
+++ b/etc/config/RTG/biomes/thaumcraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -67,6 +73,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -101,6 +113,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/thaumcraft.cfg
+++ b/etc/config/RTG/biomes/thaumcraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -31,6 +43,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -53,6 +77,18 @@ biome {
         taintedland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/tofucraft.cfg
+++ b/etc/config/RTG/biomes/tofucraft.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -66,6 +72,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -102,6 +114,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -136,6 +154,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -172,6 +196,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -206,6 +236,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -242,6 +278,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -277,6 +319,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -311,6 +359,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/tofucraft.cfg
+++ b/etc/config/RTG/biomes/tofucraft.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -30,6 +42,18 @@ biome {
         tofubuildings {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -54,6 +78,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -76,6 +112,18 @@ biome {
         tofuextremehillsedge {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -100,6 +148,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -122,6 +182,18 @@ biome {
         tofuforesthills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -146,6 +218,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -169,6 +253,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -191,6 +287,18 @@ biome {
         tofuriver {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=

--- a/etc/config/RTG/biomes/vampirism.cfg
+++ b/etc/config/RTG/biomes/vampirism.cfg
@@ -32,6 +32,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 

--- a/etc/config/RTG/biomes/vampirism.cfg
+++ b/etc/config/RTG/biomes/vampirism.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 

--- a/etc/config/RTG/biomes/vanilla.cfg
+++ b/etc/config/RTG/biomes/vanilla.cfg
@@ -35,6 +35,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -78,6 +84,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -123,6 +135,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -160,6 +178,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -205,6 +229,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -239,6 +269,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -278,6 +314,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -316,6 +358,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -353,6 +401,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -395,6 +449,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -429,6 +489,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -465,6 +531,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -499,6 +571,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -550,6 +628,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -600,6 +684,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -647,6 +737,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -691,6 +787,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -731,6 +833,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -776,6 +884,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -819,6 +933,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -864,6 +984,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -905,6 +1031,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -939,6 +1071,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -987,6 +1125,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1025,6 +1169,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1059,6 +1209,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1107,6 +1263,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1145,6 +1307,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1182,6 +1350,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1224,6 +1398,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1265,6 +1445,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1302,6 +1488,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1341,6 +1533,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1379,6 +1577,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1413,6 +1617,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1449,6 +1659,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1483,6 +1699,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1519,6 +1741,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1553,6 +1781,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1589,6 +1823,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1624,6 +1864,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1658,6 +1904,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1700,6 +1952,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1734,6 +1992,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1773,6 +2037,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1807,6 +2077,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1855,6 +2131,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1898,6 +2180,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -1943,6 +2231,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -1981,6 +2275,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2015,6 +2315,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2051,6 +2357,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2086,6 +2398,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2120,6 +2438,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2159,6 +2483,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2196,6 +2526,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true
@@ -2235,6 +2571,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2273,6 +2615,12 @@ biome {
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
 
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
+
             #  [default: true]
             B:"Use RTG Decorations"=true
 
@@ -2310,6 +2658,12 @@ biome {
 
             #  [default: ]
             S:"RTG Surface: Top Block Meta"=
+
+            # This setting controls the number of ravines that generate.
+            # LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)
+            # Set to -1 to use global setting. Set to 0 to disable ravines for this biome.
+            #  [range: -1 ~ 100, default: -1]
+            I:"Ravine Frequency"=-1
 
             #  [default: true]
             B:"Use RTG Decorations"=true

--- a/etc/config/RTG/biomes/vanilla.cfg
+++ b/etc/config/RTG/biomes/vanilla.cfg
@@ -8,6 +8,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Palm Trees"=true
 
@@ -33,6 +45,18 @@ biome {
         birchforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -66,6 +90,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -98,6 +134,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -123,6 +171,18 @@ biome {
         birchforestm {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -156,6 +216,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -178,6 +250,18 @@ biome {
         coldtaiga {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -205,6 +289,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -231,6 +327,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -256,6 +364,18 @@ biome {
         deepocean {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -286,6 +406,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -308,6 +440,18 @@ biome {
         deserthills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -332,6 +476,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -354,6 +510,18 @@ biome {
         extremehills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -393,6 +561,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -431,6 +611,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -466,6 +658,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -498,6 +702,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -526,6 +742,18 @@ biome {
         flowerforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -559,6 +787,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -590,6 +830,18 @@ biome {
         foresthills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -623,6 +875,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -652,6 +916,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -674,6 +950,18 @@ biome {
         icemountains {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -710,6 +998,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -736,6 +1036,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -758,6 +1070,18 @@ biome {
         jungle {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Cactus"=true
@@ -794,6 +1118,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -820,6 +1156,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -845,6 +1193,18 @@ biome {
         junglehills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Cactus"=true
@@ -875,6 +1235,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Cactus"=true
 
@@ -904,6 +1276,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -929,6 +1313,18 @@ biome {
         megataiga {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -956,6 +1352,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -982,6 +1390,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1004,6 +1424,18 @@ biome {
         mesabryce {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1028,6 +1460,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1050,6 +1494,18 @@ biome {
         mesaplateauf {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1074,6 +1530,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1096,6 +1564,18 @@ biome {
         mesaplateaum {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1120,6 +1600,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1143,6 +1635,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1165,6 +1669,18 @@ biome {
         ocean {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1195,6 +1711,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1217,6 +1745,18 @@ biome {
         redwoodtaigahills {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1244,6 +1784,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1266,6 +1818,18 @@ biome {
         roofedforest {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Cobwebs"=true
@@ -1302,6 +1866,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1333,6 +1909,18 @@ biome {
         savanna {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1366,6 +1954,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1392,6 +1992,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1414,6 +2026,18 @@ biome {
         savannaplateaum {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: ]
             S:"RTG Surface: Filler Block"=
@@ -1438,6 +2062,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1461,6 +2097,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: ]
             S:"RTG Surface: Filler Block"=
 
@@ -1483,6 +2131,18 @@ biome {
         swampland {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1510,6 +2170,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1535,6 +2207,18 @@ biome {
         taiga {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true
@@ -1562,6 +2246,18 @@ biome {
             #  [default: true]
             B:"Allow Villages"=true
 
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
+
             #  [default: true]
             B:"RTG Decoration: Logs"=true
 
@@ -1587,6 +2283,18 @@ biome {
         taigam {
             #  [default: true]
             B:"Allow Villages"=true
+
+            # This setting controls the size of caves.
+            # HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Density"=-1
+
+            # This setting controls the number of caves that generate.
+            # LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)
+            # Set to -1 to use global setting. Set to 0 to disable caves for this biome.
+            #  [range: -1 ~ 40, default: -1]
+            I:"Cave Frequency"=-1
 
             #  [default: true]
             B:"RTG Decoration: Logs"=true

--- a/etc/config/RTG/rtg.cfg
+++ b/etc/config/RTG/rtg.cfg
@@ -175,6 +175,10 @@ ravines {
 
 
 "rivers and scenic lakes" {
+    # Higher numbers make the large-scale cut-off noise have a greater effect. Defaults to 0.5
+    #  [range: 0.0 ~ 2.0, default: 0.5]
+    S:"Amplitude of Large-Scale River Cut Off"=0.5
+
     # Defaults to 1 (standard frequency)
     #  [range: 0.0 ~ 10.0, default: 1.0]
     S:"Lake Frequency Multipler"=1.0
@@ -198,6 +202,10 @@ ravines {
     # Defaults to 1 (standard width)
     #  [range: 0.0 ~ 10.0, default: 1.0]
     S:"River Width Multipler"=1.0
+
+    # Higher numbers make grassy areas near rivers bigger, but also more rare. Defaults to 350
+    #  [range: 50.0 ~ 5000.0, default: 350.0]
+    S:"Scale of Large-Scale River Cut Off"=350.0
 }
 
 

--- a/src/main/java/rtg/api/biome/BiomeConfig.java
+++ b/src/main/java/rtg/api/biome/BiomeConfig.java
@@ -38,7 +38,10 @@ public class BiomeConfig {
     public static final String caveDensityName = "Cave Density";
     
     public static final String caveFrequencyId = "caveFrequency";
-    public static final String caveFrequencyName = "Cave Frequency";    
+    public static final String caveFrequencyName = "Cave Frequency";
+    
+    public static final String ravineFrequencyId = "ravineFrequency";
+    public static final String ravineFrequencyName = "Ravine Frequency";
 
     public BiomeConfig(String modSlug, String biomeSlug)
     {
@@ -58,6 +61,7 @@ public class BiomeConfig {
         this.addProperty(new BiomeConfigProperty(surfaceFillerBlockMetaId, Type.STRING, surfaceFillerBlockMetaName, "", ""));
         this.addProperty(new BiomeConfigProperty(caveDensityId, Type.INTEGER, caveDensityName, "This setting controls the size of caves." + Configuration.NEW_LINE + "HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)" + Configuration.NEW_LINE + "Set to -1 to use global setting. Set to 0 to disable caves for this biome." + Configuration.NEW_LINE, -1, -1, 40));
         this.addProperty(new BiomeConfigProperty(caveFrequencyId, Type.INTEGER, caveFrequencyName, "This setting controls the number of caves that generate." + Configuration.NEW_LINE + "LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)" + Configuration.NEW_LINE + "Set to -1 to use global setting. Set to 0 to disable caves for this biome." + Configuration.NEW_LINE, -1, -1, 40));
+        this.addProperty(new BiomeConfigProperty(ravineFrequencyId, Type.INTEGER, ravineFrequencyName, "This setting controls the number of ravines that generate." + Configuration.NEW_LINE + "LOWER values = MORE ravines & MORE lag. (50 = vanilla ravine frequency)" + Configuration.NEW_LINE + "Set to -1 to use global setting. Set to 0 to disable ravines for this biome." + Configuration.NEW_LINE, -1, -1, 100));
     }
     
     public void addProperty(BiomeConfigProperty property)

--- a/src/main/java/rtg/api/biome/BiomeConfig.java
+++ b/src/main/java/rtg/api/biome/BiomeConfig.java
@@ -2,6 +2,7 @@ package rtg.api.biome;
 
 import java.util.ArrayList;
 
+import net.minecraftforge.common.config.Configuration;
 import rtg.api.biome.BiomeConfigProperty.Type;
 
 
@@ -32,6 +33,12 @@ public class BiomeConfig {
     
     public static final String surfaceFillerBlockMetaId = "surfaceFillerBlockMeta";
     public static final String surfaceFillerBlockMetaName = "RTG Surface: Filler Block Meta";
+    
+    public static final String caveDensityId = "caveDensity";
+    public static final String caveDensityName = "Cave Density";
+    
+    public static final String caveFrequencyId = "caveFrequency";
+    public static final String caveFrequencyName = "Cave Frequency";    
 
     public BiomeConfig(String modSlug, String biomeSlug)
     {
@@ -49,6 +56,8 @@ public class BiomeConfig {
         this.addProperty(new BiomeConfigProperty(surfaceTopBlockMetaId, Type.STRING, surfaceTopBlockMetaName, "", ""));
         this.addProperty(new BiomeConfigProperty(surfaceFillerBlockId, Type.STRING, surfaceFillerBlockName, "", ""));
         this.addProperty(new BiomeConfigProperty(surfaceFillerBlockMetaId, Type.STRING, surfaceFillerBlockMetaName, "", ""));
+        this.addProperty(new BiomeConfigProperty(caveDensityId, Type.INTEGER, caveDensityName, "This setting controls the size of caves." + Configuration.NEW_LINE + "HIGHER values = BIGGER caves & MORE lag. (14 = vanilla cave density)" + Configuration.NEW_LINE + "Set to -1 to use global setting. Set to 0 to disable caves for this biome." + Configuration.NEW_LINE, -1, -1, 40));
+        this.addProperty(new BiomeConfigProperty(caveFrequencyId, Type.INTEGER, caveFrequencyName, "This setting controls the number of caves that generate." + Configuration.NEW_LINE + "LOWER values = MORE caves & MORE lag. (6 = vanilla cave frequency)" + Configuration.NEW_LINE + "Set to -1 to use global setting. Set to 0 to disable caves for this biome." + Configuration.NEW_LINE, -1, -1, 40));
     }
     
     public void addProperty(BiomeConfigProperty property)

--- a/src/main/java/rtg/world/gen/MapGenCavesRTG.java
+++ b/src/main/java/rtg/world/gen/MapGenCavesRTG.java
@@ -286,13 +286,17 @@ public class MapGenCavesRTG extends MapGenCaves
     
     private boolean isExceptionBiome(BiomeGenBase biome)
     {
-        boolean booException = false;
+        if (biome.biomeID == BiomeGenBase.mushroomIsland.biomeID) {
+        	return true;
+        }
+        else if (biome.biomeID == BiomeGenBase.beach.biomeID) {
+        	return true;
+        }
+        else if (biome.biomeID == BiomeGenBase.desert.biomeID) {
+        	return true;
+        }
         
-        if (biome.biomeID == BiomeGenBase.mushroomIsland.biomeID) booException = true;
-        if (biome.biomeID == BiomeGenBase.beach.biomeID) booException = true;
-        if (biome.biomeID == BiomeGenBase.desert.biomeID) booException = true;
-        
-        return booException;
+        return false;
     }
 
     //Determine if the block at the specified location is the top block for the biome, we take into account

--- a/src/main/java/rtg/world/gen/MapGenCavesRTG.java
+++ b/src/main/java/rtg/world/gen/MapGenCavesRTG.java
@@ -2,14 +2,15 @@ package rtg.world.gen;
 
 import java.util.Random;
 
-import rtg.config.rtg.ConfigRTG;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.gen.MapGenCaves;
+import rtg.api.biome.BiomeConfig;
+import rtg.config.rtg.ConfigRTG;
+import rtg.world.biome.realistic.RealisticBiomeBase;
 
 public class MapGenCavesRTG extends MapGenCaves
 {
@@ -210,13 +211,26 @@ public class MapGenCavesRTG extends MapGenCaves
     }
 
     @Override
-    protected void func_151538_a(World p_151538_1_, int p_151538_2_, int p_151538_3_, int p_151538_4_, int p_151538_5_, Block[] p_151538_6_)
+    protected void func_151538_a(World world, int chunkX, int chunkZ, int p_151538_4_, int p_151538_5_, Block[] p_151538_6_)
     {
+    	// Return early if caves are disabled.
         enableCaves = ConfigRTG.enableCaves;
+        if (!enableCaves) {
+            return;
+        }
+        
+        // Use the global settings by default.
         caveDensity = ConfigRTG.caveDensity;
         caveFrequency = ConfigRTG.caveFrequency;
+
+        // If the user has set biome-specific settings, let's use those instead.
+        BiomeGenBase biome = world.getBiomeGenForCoords(this.rand.nextInt(16) + chunkX * 16, this.rand.nextInt(16) + chunkZ * 16);
+        RealisticBiomeBase realisticBiome = RealisticBiomeBase.getBiome(biome.biomeID);
+        caveDensity = (realisticBiome.config._int(BiomeConfig.caveDensityId) > -1) ? realisticBiome.config._int(BiomeConfig.caveDensityId) : caveDensity;
+        caveFrequency = (realisticBiome.config._int(BiomeConfig.caveFrequencyId) > -1) ? realisticBiome.config._int(BiomeConfig.caveFrequencyId) : caveFrequency;
         
-        if (!enableCaves) {
+    	// Return early if caves are disabled.
+        if (caveDensity < 1 || caveFrequency < 1) {
             return;
         }
         
@@ -235,9 +249,9 @@ public class MapGenCavesRTG extends MapGenCaves
 
         for (int j1 = 0; j1 < i1; ++j1)
         {
-            double d0 = (double)(p_151538_2_ * 16 + this.rand.nextInt(16));
+            double d0 = (double)(chunkX * 16 + this.rand.nextInt(16));
             double d1 = (double)this.rand.nextInt(this.rand.nextInt(120) + 8);
-            double d2 = (double)(p_151538_3_ * 16 + this.rand.nextInt(16));
+            double d2 = (double)(chunkZ * 16 + this.rand.nextInt(16));
             int k1 = 1;
 
             if (this.rand.nextInt(4) == 0)
@@ -274,9 +288,9 @@ public class MapGenCavesRTG extends MapGenCaves
     {
         boolean booException = false;
         
-        if (biome == BiomeGenBase.mushroomIsland) booException = true;
-        if (biome == BiomeGenBase.beach) booException = true;
-        if (biome == BiomeGenBase.desert) booException = true;
+        if (biome.biomeID == BiomeGenBase.mushroomIsland.biomeID) booException = true;
+        if (biome.biomeID == BiomeGenBase.beach.biomeID) booException = true;
+        if (biome.biomeID == BiomeGenBase.desert.biomeID) booException = true;
         
         return booException;
     }

--- a/src/main/java/rtg/world/gen/MapGenRavineRTG.java
+++ b/src/main/java/rtg/world/gen/MapGenRavineRTG.java
@@ -2,14 +2,15 @@ package rtg.world.gen;
 
 import java.util.Random;
 
-import rtg.config.rtg.ConfigRTG;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.gen.MapGenRavine;
+import rtg.api.biome.BiomeConfig;
+import rtg.config.rtg.ConfigRTG;
+import rtg.world.biome.realistic.RealisticBiomeBase;
 
 public class MapGenRavineRTG extends MapGenRavine
 {
@@ -201,20 +202,32 @@ public class MapGenRavineRTG extends MapGenRavine
     }
 
     @Override
-    protected void func_151538_a(World p_151538_1_, int p_151538_2_, int p_151538_3_, int p_151538_4_, int p_151538_5_, Block[] p_151538_6_)
+    protected void func_151538_a(World world, int chunkX, int chunkZ, int p_151538_4_, int p_151538_5_, Block[] p_151538_6_)
     {
+    	// Return early if ravines are disabled.
         enableRavines = ConfigRTG.enableRavines;
+        if (!enableRavines) {
+            return;
+        }
+        
+        // Use the global settings by default.
         ravineFrequency = ConfigRTG.ravineFrequency;
         
-        if (!enableRavines) {
+        // If the user has set biome-specific settings, let's use those instead.
+        BiomeGenBase biome = world.getBiomeGenForCoords(this.rand.nextInt(16) + chunkX * 16, this.rand.nextInt(16) + chunkZ * 16);
+        RealisticBiomeBase realisticBiome = RealisticBiomeBase.getBiome(biome.biomeID);
+        ravineFrequency = (realisticBiome.config._int(BiomeConfig.ravineFrequencyId) > -1) ? realisticBiome.config._int(BiomeConfig.ravineFrequencyId) : ravineFrequency;
+        
+    	// Return early if ravines are disabled.
+        if (ravineFrequency < 1) {
             return;
         }
         
         if (this.rand.nextInt(ravineFrequency) == 0)
         {
-            double d0 = (double)(p_151538_2_ * 16 + this.rand.nextInt(16));
+            double d0 = (double)(chunkX * 16 + this.rand.nextInt(16));
             double d1 = (double)(this.rand.nextInt(this.rand.nextInt(40) + 8) + 20);
-            double d2 = (double)(p_151538_3_ * 16 + this.rand.nextInt(16));
+            double d2 = (double)(chunkZ * 16 + this.rand.nextInt(16));
             byte b0 = 1;
 
             for (int i1 = 0; i1 < b0; ++i1)
@@ -236,9 +249,16 @@ public class MapGenRavineRTG extends MapGenRavine
     //Exception biomes to make sure we generate like vanilla
     private boolean isExceptionBiome(BiomeGenBase biome)
     {
-        if (biome == BiomeGenBase.mushroomIsland) return true;
-        if (biome == BiomeGenBase.beach) return true;
-        if (biome == BiomeGenBase.desert) return true;
+        if (biome.biomeID == BiomeGenBase.mushroomIsland.biomeID) {
+        	return true;
+        }
+        else if (biome.biomeID == BiomeGenBase.beach.biomeID) {
+        	return true;
+        }
+        else if (biome.biomeID == BiomeGenBase.desert.biomeID) {
+        	return true;
+        }
+        
         return false;
     }
 


### PR DESCRIPTION
This is what I've done for the biome-specific cave settings.

It looks worse than it was (most of the changed files are the updated example configs). The only two files involved here are:

```
src/main/java/rtg/api/biome/BiomeConfig.java
src/main/java/rtg/world/gen/MapGenCavesRTG.java
```

I've tested it on a few biomes, and everything seems to be working correctly.

The only concern I have is the way I'm checking for the current biome in MapGenCavesRTG:

`BiomeGenBase biome = world.getBiomeGenForCoords(this.rand.nextInt(16) + chunkX * 16, this.rand.nextInt(16) + chunkZ * 16);`

I'm not very good with the whole chunk/world coord stuff, but it seems to work alright.

Can anyone see any problems with how I'm getting the current biome?