### PR TITLE
Delayed Decoration Revamp

### DIFF
--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.common.eventhandler.Event.Result;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
+import java.util.WeakHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
@@ -28,12 +29,16 @@ import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
 import net.minecraftforge.event.terraingen.InitMapGenEvent;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.WorldTypeEvent;
+import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
+import rtg.util.Acceptor;
 
 public class EventManagerRTG
 {
 
     public RealisticBiomeBase biome = null;
+    private WeakHashMap<Integer,Acceptor<ChunkEvent.Load>> chunkLoadEvents =
+            new WeakHashMap<Integer,Acceptor<ChunkEvent.Load>> ();
     
     public EventManagerRTG()
     {
@@ -257,5 +262,18 @@ public class EventManagerRTG
         }
 
         return false;
+    }
+
+    @SubscribeEvent
+    public void onChunkLoadEvent(ChunkEvent.Load loadEvent)  {
+        Integer dimension = loadEvent.world.provider.dimensionId;
+        Acceptor<ChunkEvent.Load> acceptor = chunkLoadEvents.get(dimension);
+        if (acceptor != null) {
+            acceptor.accept(loadEvent);
+        }
+    }
+
+    public void setDimensionChunkLoadEvent(int dimension, Acceptor<ChunkEvent.Load> action) {
+        chunkLoadEvents.put(dimension, action);
     }
 }

--- a/src/main/java/rtg/util/Acceptor.java
+++ b/src/main/java/rtg/util/Acceptor.java
@@ -1,0 +1,26 @@
+
+package rtg.util;
+
+
+/**
+ *
+ * @author Zeno410
+ */
+public abstract class Acceptor<Type> {
+    public abstract void accept(Type accepted);
+
+    public static class Ignorer<IgnoredType> extends Acceptor<IgnoredType> {
+        public void accept(IgnoredType ignored) {}
+    }
+
+    public static class OneShotRedirector<RedirectedType> extends Acceptor<RedirectedType> {
+        private Acceptor<RedirectedType> target;
+        public void accept(RedirectedType redirected) {
+            target.accept(redirected);
+            target = null;
+        }
+        public void redirectTo(Acceptor<RedirectedType> newTarget) {
+            target = newTarget;
+        }
+    }
+}


### PR DESCRIPTION
Delayed Decoration altered to work primarily through ChunkEvent.Load to
fix assorted bug. Currently has trackers for re-generation and
re-decoration that need to be removed for a production release.