### PR TITLE
Papering over ocean floor bug

### DIFF
--- a/src/main/java/rtg/world/gen/terrain/TerrainBase.java
+++ b/src/main/java/rtg/world/gen/terrain/TerrainBase.java
@@ -8,7 +8,7 @@ public class TerrainBase
 {
     protected float base; // added as most terrains have this;
     protected final float minOceanFloor; // The lowest Y coord an ocean floor is allowed to be.
-    public static final float minimumOceanFloor = 30f; // The lowest Y coord an ocean floor is allowed to be.
+    public static final float minimumOceanFloor = 30.01f; // The lowest Y coord an ocean floor is allowed to be.
     protected final float minDuneHeight; // The strength factor to which the dune height config option is added.
     public static final float minimumDuneHeight = 21f; // The strength factor to which the dune height config option is added.
     protected final float groundNoiseAmplitudeHills;


### PR DESCRIPTION
Apparently caused by a small rounding error in the biome weighting. The
effect is less that 0.01, so completely unnoticeable apart from flat
areas right at a block cutoff. Possibly an unavoidable error due to
floating-point precision limits.