### PR TITLE
Vanilla Ice Plains Spikes biome by default.

### DIFF
--- a/src/main/java/rtg/api/biome/vanilla/config/BiomeConfigVanillaIcePlainsSpikes.java
+++ b/src/main/java/rtg/api/biome/vanilla/config/BiomeConfigVanillaIcePlainsSpikes.java
@@ -20,8 +20,8 @@ public class BiomeConfigVanillaIcePlainsSpikes extends BiomeConfigVanillaBase
     {
         super("iceplainsspikes");
         
-        this.addProperty(new BiomeConfigProperty(decorationIceTreesId, Type.BOOLEAN, decorationIceTreesName, "", true));
-        this.addProperty(new BiomeConfigProperty(decorationIceShrubsId, Type.BOOLEAN, decorationIceShrubsName, "", true));
-        this.addProperty(new BiomeConfigProperty(iceSpikeChanceId, Type.INTEGER, iceSpikeChanceName, "1/x chance that packed ice spikes/lakes will generate when they normally would." + Configuration.NEW_LINE + "1 = Always generate if possible; 2 = 50% chance; 4 = 25% chance" + Configuration.NEW_LINE + "Set to 0 to disable ice spikes." + Configuration.NEW_LINE, 3, 0, Integer.MAX_VALUE));
+        this.addProperty(new BiomeConfigProperty(decorationIceTreesId, Type.BOOLEAN, decorationIceTreesName, "", false));
+        this.addProperty(new BiomeConfigProperty(decorationIceShrubsId, Type.BOOLEAN, decorationIceShrubsName, "", false));
+        this.addProperty(new BiomeConfigProperty(iceSpikeChanceId, Type.INTEGER, iceSpikeChanceName, "1/x chance that packed ice spikes/lakes will generate when they normally would." + Configuration.NEW_LINE + "1 = Always generate if possible; 2 = 50% chance; 4 = 25% chance" + Configuration.NEW_LINE + "Set to 0 to disable ice spikes." + Configuration.NEW_LINE, 1, 0, Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
Users will need to delete their vanilla.cfg biome config file in order for these changes to take effect.
