### PR TITLE
Village-aware decos.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -25,8 +25,9 @@ mod_deps=after:abyssalcraft@[1.9.1.2,);\
           after:Growthcraft|Bamboo@[1.7.10-2.5.0,);\
           after:Highlands@[2.2.3,);\
           after:ICMod@[1.5.0,);\
-          after:mod_IDT;\
           after:lom@[1.7.10-3.2.0,);\
+          after:Mariculture@[1.7.10-1.2.4.2a-5,);\
+          after:mod_IDT;\
           after:Railcraft@[9.7.0.0,);\
           after:RidiculousWorld@[0.1,);\
           after:sushicraft@[14.4,);\

--- a/src/main/java/rtg/util/WorldUtil.java
+++ b/src/main/java/rtg/util/WorldUtil.java
@@ -1,0 +1,75 @@
+package rtg.util;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+
+public class WorldUtil
+{
+	private World world;
+	
+	public WorldUtil(World world)
+	{
+		this.world = world;
+	}
+	
+	/**
+	 * Checks a given coordinate to see if it is surrounded by a given block, usually air.
+	 * This method only checks along the same Y coord.
+	 */
+	public boolean isSurroundedByBlock(Block checkBlock, int checkDistance, SurroundCheckType checkType, Random rand, int x, int y, int z)
+	{
+		switch (checkType)
+		{
+			case FULL: // Checks the entire radius around the coord.
+				
+				for (int ix = -checkDistance; ix <= checkDistance; ix++) {
+					for (int iz = -checkDistance; iz <= checkDistance; iz++) {
+						
+						if (x == ix && z == iz) continue;
+						
+						if (this.world.getBlock(x + ix, y, z + iz) != checkBlock) return false;
+					}
+				}
+
+				break;
+				
+			case CARDINAL: // Checks the N/E/S/W directions around the coord.
+				
+				for (int i = checkDistance; i > 0; i--) {
+					
+					if (this.world.getBlock(x, y, z + i) != checkBlock) return false;
+					if (this.world.getBlock(x, y, z - i) != checkBlock) return false;
+					if (this.world.getBlock(x + i, y, z) != checkBlock) return false;
+					if (this.world.getBlock(x - i, y, z) != checkBlock) return false;
+				}
+				
+				break;
+				
+			case ORDINAL: // Checks the NE/SE/SW/NW directions around the coord.
+				
+				for (int i = checkDistance; i > 0; i--) {
+					
+					if (this.world.getBlock(x + i, y, z + i) != checkBlock) return false;
+					if (this.world.getBlock(x + i, y, z - i) != checkBlock) return false;
+					if (this.world.getBlock(x - i, y, z + i) != checkBlock) return false;
+					if (this.world.getBlock(x - i, y, z - i) != checkBlock) return false;
+				}
+				
+				break;
+				
+			default:
+				break;
+		}
+		
+		return true;
+	}
+	
+	public enum SurroundCheckType
+	{
+		FULL,
+		CARDINAL,
+		ORDINAL
+	}
+}

--- a/src/main/java/rtg/world/biome/deco/DecoAbyssalCraftTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoAbyssalCraftTree.java
@@ -58,7 +58,7 @@ public class DecoAbyssalCraftTree extends DecoTree
     }
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoBase.java
+++ b/src/main/java/rtg/world/biome/deco/DecoBase.java
@@ -55,8 +55,9 @@ public class DecoBase
 	 * @param cell
 	 * @param strength
 	 * @param river
+	 * @param hasPlacedVillageBlocks
 	 */
-	public boolean preGenerate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public boolean preGenerate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.checkRiver) {
 			
@@ -81,8 +82,9 @@ public class DecoBase
 	 * @param cell
 	 * @param strength
 	 * @param river
+	 * @param hasPlacedVillageBlocks
 	 */
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		
     }

--- a/src/main/java/rtg/world/biome/deco/DecoBaseBiomeDecorations.java
+++ b/src/main/java/rtg/world/biome/deco/DecoBaseBiomeDecorations.java
@@ -58,7 +58,7 @@ public class DecoBaseBiomeDecorations extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
             

--- a/src/main/java/rtg/world/biome/deco/DecoBoulder.java
+++ b/src/main/java/rtg/world/biome/deco/DecoBoulder.java
@@ -8,6 +8,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
+import rtg.util.WorldUtil;
+import rtg.util.WorldUtil.SurroundCheckType;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.gen.feature.WorldGenBlob;
 
@@ -51,6 +53,7 @@ public class DecoBoulder extends DecoBase
 	{
 		if (this.allowed) {
 			
+			WorldUtil worldUtil = new WorldUtil(world);
 			WorldGenerator worldGenerator = new WorldGenBlob(boulderBlock, this.boulderMeta, 0, rand, this.water);
 			
             for (int l1 = 0; l1 < this.strengthFactor * strength; ++l1)
@@ -60,6 +63,14 @@ public class DecoBoulder extends DecoBase
                 int k1 = world.getHeightValue(i1, j1);
                 
                 if (k1 >= this.minY && k1 <= this.maxY && rand.nextInt(this.chance) == 0) {
+                	
+	                // If we're in a village, check to make sure the boulder has extra room to grow to avoid corrupting the village.
+	                if (hasPlacedVillageBlocks) {
+		                if (!worldUtil.isSurroundedByBlock(Blocks.air, 2, SurroundCheckType.CARDINAL, rand, i1, k1, j1)) {
+		                	return;
+		                }
+	                }
+	                
                 	worldGenerator.generate(world, rand, i1, k1, j1);
                 }
             }

--- a/src/main/java/rtg/world/biome/deco/DecoBoulder.java
+++ b/src/main/java/rtg/world/biome/deco/DecoBoulder.java
@@ -47,7 +47,7 @@ public class DecoBoulder extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoCactus.java
+++ b/src/main/java/rtg/world/biome/deco/DecoCactus.java
@@ -49,7 +49,7 @@ public class DecoCactus extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoCobwebs.java
+++ b/src/main/java/rtg/world/biome/deco/DecoCobwebs.java
@@ -48,7 +48,7 @@ public class DecoCobwebs extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoDeadBush.java
+++ b/src/main/java/rtg/world/biome/deco/DecoDeadBush.java
@@ -43,7 +43,7 @@ public class DecoDeadBush extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoDesertWell.java
+++ b/src/main/java/rtg/world/biome/deco/DecoDesertWell.java
@@ -39,7 +39,7 @@ public class DecoDesertWell extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoDoubleGrass.java
+++ b/src/main/java/rtg/world/biome/deco/DecoDoubleGrass.java
@@ -41,7 +41,7 @@ public class DecoDoubleGrass extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoEBRockSpire.java
+++ b/src/main/java/rtg/world/biome/deco/DecoEBRockSpire.java
@@ -48,7 +48,7 @@ public class DecoEBRockSpire extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 

--- a/src/main/java/rtg/world/biome/deco/DecoEBTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoEBTree.java
@@ -64,7 +64,7 @@ public class DecoEBTree extends DecoTree
     }
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoFallenTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoFallenTree.java
@@ -82,7 +82,7 @@ public class DecoFallenTree extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 

--- a/src/main/java/rtg/world/biome/deco/DecoFallenTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoFallenTree.java
@@ -8,6 +8,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
+import rtg.util.WorldUtil;
+import rtg.util.WorldUtil.SurroundCheckType;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.gen.feature.WorldGenLog;
 
@@ -87,7 +89,8 @@ public class DecoFallenTree extends DecoBase
 		if (this.allowed) {
 
 			float noise = simplex.noise2(chunkX / this.distribution.noiseDivisor, chunkY / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
-
+			WorldUtil worldUtil = new WorldUtil(world);
+			
 			//Do we want to choose a random log?
 			if (this.useRandomLogs) {
 				
@@ -96,14 +99,17 @@ public class DecoFallenTree extends DecoBase
 			}
 			
 			WorldGenerator worldGenerator = null;
+			int finalSize = 4;
         	if (this.maxSize > this.minSize) {
-        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, this.minSize + rand.nextInt(this.maxSize - this.minSize));
+        		finalSize = this.minSize + rand.nextInt(this.maxSize - this.minSize);
+        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, finalSize);
         	}
         	else if (this.maxSize == this.minSize) {
-        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, this.minSize);
+        		finalSize = this.minSize;
+        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, finalSize);
         	}
         	else {
-        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, 4);
+        		worldGenerator = new WorldGenLog(this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta, finalSize);
         	}
 			
             for (int i = 0; i < this.loops; i++)
@@ -116,6 +122,13 @@ public class DecoFallenTree extends DecoBase
                     
                     if (y22 <= this.maxY) {
                     	
+		                // If we're in a village, check to make sure the log has extra room to grow to avoid corrupting the village.
+		                if (hasPlacedVillageBlocks) {
+			                if (!worldUtil.isSurroundedByBlock(Blocks.air, finalSize, SurroundCheckType.CARDINAL, rand, x22, y22, z22)) {
+			                	return;
+			                }
+		                }
+		                
                     	worldGenerator.generate(world, rand, x22, y22, z22);
                     }
                 }

--- a/src/main/java/rtg/world/biome/deco/DecoFlowersRTG.java
+++ b/src/main/java/rtg/world/biome/deco/DecoFlowersRTG.java
@@ -71,7 +71,7 @@ public class DecoFlowersRTG extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 

--- a/src/main/java/rtg/world/biome/deco/DecoGrass.java
+++ b/src/main/java/rtg/world/biome/deco/DecoGrass.java
@@ -82,7 +82,7 @@ public class DecoGrass extends DecoBase
         grassGenerator = new WorldGenGrass.RandomType(randomGrassBlocks,randomGrassMetas);
     }
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoGrassDoubleTallgrass.java
+++ b/src/main/java/rtg/world/biome/deco/DecoGrassDoubleTallgrass.java
@@ -45,7 +45,7 @@ public class DecoGrassDoubleTallgrass extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoHLTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoHLTree.java
@@ -62,7 +62,7 @@ public class DecoHLTree extends DecoTree
     }
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoJungleCacti.java
+++ b/src/main/java/rtg/world/biome/deco/DecoJungleCacti.java
@@ -44,7 +44,7 @@ public class DecoJungleCacti extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 

--- a/src/main/java/rtg/world/biome/deco/DecoJungleGrassVines.java
+++ b/src/main/java/rtg/world/biome/deco/DecoJungleGrassVines.java
@@ -45,7 +45,7 @@ public class DecoJungleGrassVines extends DecoBase
 	 * No config options for this one yet. Just ripped it directly from the old code.
 	 */
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int worldX, int worldY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int worldX, int worldY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoJungleLilypadVines.java
+++ b/src/main/java/rtg/world/biome/deco/DecoJungleLilypadVines.java
@@ -40,7 +40,7 @@ public class DecoJungleLilypadVines extends DecoBase
 	 * No config options for this one yet. Just ripped it directly from the old code.
 	 */
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int blockX, int blockY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int blockX, int blockY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoLargeFernDoubleTallgrass.java
+++ b/src/main/java/rtg/world/biome/deco/DecoLargeFernDoubleTallgrass.java
@@ -48,7 +48,7 @@ public class DecoLargeFernDoubleTallgrass extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoMushrooms.java
+++ b/src/main/java/rtg/world/biome/deco/DecoMushrooms.java
@@ -54,7 +54,7 @@ public class DecoMushrooms extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoPond.java
+++ b/src/main/java/rtg/world/biome/deco/DecoPond.java
@@ -21,7 +21,7 @@ public class DecoPond extends DecoBase {
     public int chunksPerPond;
 
     @Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed&&ConfigRTG.waterSurfaceLakeChance>0) {
 

--- a/src/main/java/rtg/world/biome/deco/DecoPumpkin.java
+++ b/src/main/java/rtg/world/biome/deco/DecoPumpkin.java
@@ -53,7 +53,7 @@ public class DecoPumpkin extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoReed.java
+++ b/src/main/java/rtg/world/biome/deco/DecoReed.java
@@ -40,7 +40,7 @@ public class DecoReed extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoShrub.java
+++ b/src/main/java/rtg/world/biome/deco/DecoShrub.java
@@ -75,10 +75,10 @@ public class DecoShrub extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
-
+			
 			// Shrub size.
 			this.size = (this.size == -1) ? rand.nextInt(4) + 1 : this.size;
 			if (this.minSize > 0 && this.maxSize > 0 && this.maxSize >= this.minSize) {

--- a/src/main/java/rtg/world/biome/deco/DecoShrub.java
+++ b/src/main/java/rtg/world/biome/deco/DecoShrub.java
@@ -8,6 +8,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
+import rtg.util.WorldUtil;
+import rtg.util.WorldUtil.SurroundCheckType;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.gen.feature.WorldGenShrubRTG;
 
@@ -64,7 +66,7 @@ public class DecoShrub extends DecoBase
 		this.logMeta = (byte)0;
 		this.leavesBlock = Blocks.leaves;
 		this.leavesMeta = (byte)0;
-		
+
 		this.addDecoTypes(DecoType.SHRUB);
 	}
 	
@@ -100,6 +102,7 @@ public class DecoShrub extends DecoBase
         		this.leavesMeta = this.randomLeavesMetas[rnd];
             }
 
+            WorldUtil worldUtil = new WorldUtil(world);
             WorldGenerator worldGenerator = new WorldGenShrubRTG(this.size, this.logBlock, this.logMeta, this.leavesBlock, this.leavesMeta);
             
 			int loopCount = this.loops;
@@ -113,16 +116,28 @@ public class DecoShrub extends DecoBase
                 if (this.notEqualsZerochance > 1) {
                 	
 	                if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.notEqualsZerochance) != 0) {
-	                	worldGenerator.generate(world, rand, intX, intY, intZ);
+	                	generateWorldGenerator(worldGenerator, worldUtil, world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
 	                }
                 }
                 else {
                 	
 	                if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-	                	worldGenerator.generate(world, rand, intX, intY, intZ);
+	                	generateWorldGenerator(worldGenerator, worldUtil, world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
 	                }
                 }
             }
 		}
+	}
+	
+	private boolean generateWorldGenerator(WorldGenerator worldGenerator, WorldUtil worldUtil, World world, Random rand, int x, int y, int z, boolean hasPlacedVillageBlocks)
+	{
+        // If we're in a village, check to make sure the shrub has extra room to grow to avoid corrupting the village.
+        if (hasPlacedVillageBlocks) {
+            if (!worldUtil.isSurroundedByBlock(Blocks.air, 2, SurroundCheckType.CARDINAL, rand, x, y, z)) {
+            	return false;
+            }
+        }
+        
+		return worldGenerator.generate(world, rand, x, y, z);
 	}
 }

--- a/src/main/java/rtg/world/biome/deco/DecoTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoTree.java
@@ -141,7 +141,7 @@ public class DecoTree extends DecoBase
         return super.properlyDefined();
     }
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			

--- a/src/main/java/rtg/world/biome/deco/DecoTree.java
+++ b/src/main/java/rtg/world/biome/deco/DecoTree.java
@@ -12,6 +12,8 @@ import net.minecraftforge.event.terraingen.TerrainGen;
 import rtg.util.CellNoise;
 import rtg.util.OpenSimplexNoise;
 import rtg.util.RandomUtil;
+import rtg.util.WorldUtil;
+import rtg.util.WorldUtil.SurroundCheckType;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.gen.feature.tree.rtg.TreeRTG;
 
@@ -140,6 +142,7 @@ public class DecoTree extends DecoBase
         }
         return super.properlyDefined();
     }
+    
 	@Override
 	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
@@ -147,6 +150,7 @@ public class DecoTree extends DecoBase
 			
 			if (TerrainGen.decorate(world, rand, chunkX, chunkY, TREE)) {
 				
+				WorldUtil worldUtil = new WorldUtil(world);
 				float noise = simplex.noise2(chunkX / this.distribution.noiseDivisor, chunkY / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
 
                 int loopCount = this.loops;
@@ -159,12 +163,19 @@ public class DecoTree extends DecoBase
 	                int intZ = chunkY + rand.nextInt(16);// + 8;
 	                int intY = world.getHeightValue(intX, intZ);
 	                
-	            	switch (this.treeType)
-	            	{
-		            		
-		            	case RTG_TREE:
-		            		
-		            		if (intY <= this.maxY && intY >= this.minY && isValidTreeCondition(noise, rand, strength)) {
+	                if (intY <= this.maxY && intY >= this.minY && isValidTreeCondition(noise, rand, strength)) {
+	                
+		                // If we're in a village, check to make sure the tree has extra room to grow to avoid corrupting the village.
+		                if (hasPlacedVillageBlocks) {
+			                if (!worldUtil.isSurroundedByBlock(Blocks.air, 2, SurroundCheckType.CARDINAL, rand, intX, intY, intZ)) {
+			                	return;
+			                }
+		                }
+		                
+		            	switch (this.treeType)
+		            	{
+			            		
+			            	case RTG_TREE:
 
 		            			this.tree.setLogBlock(this.logBlock);
 	            				this.tree.setLogMeta(this.logMeta);
@@ -175,24 +186,21 @@ public class DecoTree extends DecoBase
 	            				this.tree.setNoLeaves(this.noLeaves);
 		                        this.tree.setScale(1.0D, 1.0D, 1.0D);
 		                        this.tree.generate(world, rand, intX, intY, intZ);
-		            		}
-		            		
-		            		break;
-		            		
-                        case WORLDGEN:
+			            		
+			            		break;
+			            		
+	                        case WORLDGEN:
 
-                            if (intY <= this.maxY && intY >= this.minY && isValidTreeCondition(noise, rand, strength)) {
-                            	
                                 WorldGenerator worldgenerator = this.worldGen;
                                 worldgenerator.setScale(1.0D, 1.0D, 1.0D);
                                 worldgenerator.generate(world, rand, intX, intY, intZ);
-                            }
-
-                            break;
-
-		            	default:
-		            		break;
-	            	}
+	
+	                            break;
+	
+			            	default:
+			            		break;
+		            	}
+	                }
 	            }
 			}
 		}

--- a/src/main/java/rtg/world/biome/deco/helper/DecoHelper5050.java
+++ b/src/main/java/rtg/world/biome/deco/helper/DecoHelper5050.java
@@ -33,15 +33,15 @@ public class DecoHelper5050 extends DecoBase
 	}
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			
 			if (rand.nextBoolean()) {
-				this.deco1.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+				this.deco1.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 			}
 			else {
-				this.deco2.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+				this.deco2.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 			}
 		}
 	}

--- a/src/main/java/rtg/world/biome/deco/helper/DecoHelperBorder.java
+++ b/src/main/java/rtg/world/biome/deco/helper/DecoHelperBorder.java
@@ -29,17 +29,17 @@ public class DecoHelperBorder extends DecoBase{
 	}
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
         if (strength < noneBelow) return; // border is too low
         if (strength >= allAbove )  {
             // call with border 1
-            adjusted.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+            adjusted.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
         }
         else {
             // call with interpolated border
             float adjustedStrength = (strength - noneBelow)/(allAbove - noneBelow);
-            adjusted.generate(biome, world, rand, chunkX, chunkY, simplex, cell, adjustedStrength, river);
+            adjusted.generate(biome, world, rand, chunkX, chunkY, simplex, cell, adjustedStrength, river, hasPlacedVillageBlocks);
         }
 
 	}

--- a/src/main/java/rtg/world/biome/deco/helper/DecoHelperOneIn.java
+++ b/src/main/java/rtg/world/biome/deco/helper/DecoHelperOneIn.java
@@ -28,13 +28,13 @@ public class DecoHelperOneIn extends DecoBase
 	}
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 
             if (rand.nextInt(this.chances) == 0) {
 
-                this.deco.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+                this.deco.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
             }
         }
 	}

--- a/src/main/java/rtg/world/biome/deco/helper/DecoHelperRandomSplit.java
+++ b/src/main/java/rtg/world/biome/deco/helper/DecoHelperRandomSplit.java
@@ -36,7 +36,7 @@ public class DecoHelperRandomSplit extends DecoBase
     }
 	
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 			
@@ -54,7 +54,7 @@ public class DecoHelperRandomSplit extends DecoBase
 				
 				if (chosen < (this.chances[i])) {
 					
-					this.decos[i].generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+					this.decos[i].generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 				}
                 // decrement chosen for the chances missed and continue;
                 chosen -= chances[i];

--- a/src/main/java/rtg/world/biome/deco/helper/DecoHelperThisOrThat.java
+++ b/src/main/java/rtg/world/biome/deco/helper/DecoHelperThisOrThat.java
@@ -38,7 +38,7 @@ public class DecoHelperThisOrThat extends DecoBase
 	}
 
 	@Override
-	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+	public void generate(RealisticBiomeBase biome, World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
 	{
 		if (this.allowed) {
 
@@ -47,10 +47,10 @@ public class DecoHelperThisOrThat extends DecoBase
 				case EQUALS_ZERO:
 					
 					if (rand.nextInt(this.chance) == 0) {
-						this.decoThis.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+						this.decoThis.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 		            }
 					else {
-						this.decoThat.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+						this.decoThat.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 					}
 			
 					break;
@@ -58,10 +58,10 @@ public class DecoHelperThisOrThat extends DecoBase
 				case NOT_EQUALS_ZERO:
 					
 					if (rand.nextInt(this.chance) != 0) {
-						this.decoThis.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+						this.decoThis.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 		            }
 					else {
-						this.decoThat.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river);
+						this.decoThat.generate(biome, world, rand, chunkX, chunkY, simplex, cell, strength, river, hasPlacedVillageBlocks);
 					}
 			
 					break;

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -630,7 +630,7 @@ public class RealisticBiomeBase extends BiomeBase {
 
     public static ArrayList<ChunkDecoration> decoStack = new ArrayList<ChunkDecoration>();
 
-    public void decorateInAnOrderlyFashion(World world, Random rand, int worldX, int worldY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+    public void decorateInAnOrderlyFashion(World world, Random rand, int worldX, int worldY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river, boolean hasPlacedVillageBlocks)
     {
 
     	for (int i = 0; i < this.decos.size(); i++) {
@@ -642,9 +642,9 @@ public class RealisticBiomeBase extends BiomeBase {
                 }
                 throw new RuntimeException(problem);
             }
-    		if (this.decos.get(i).preGenerate(this, world, rand, worldX, worldY, simplex, cell, strength, river)) {
+    		if (this.decos.get(i).preGenerate(this, world, rand, worldX, worldY, simplex, cell, strength, river, hasPlacedVillageBlocks)) {
 
-    			this.decos.get(i).generate(this, world, rand, worldX, worldY, simplex, cell, strength, river);
+    			this.decos.get(i).generate(this, world, rand, worldX, worldY, simplex, cell, strength, river, hasPlacedVillageBlocks);
     		}
             decoStack.remove(decoStack.size()-1);
     	}

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -706,10 +706,10 @@ public class ChunkProviderRTG implements IChunkProvider
         long i1 = this.rand.nextLong() / 2L * 2L + 1L;
         long j1 = this.rand.nextLong() / 2L * 2L + 1L;
         this.rand.setSeed((long)chunkX * i1 + (long)chunkZ * j1 ^ this.worldObj.getSeed());
-        boolean flag = false;
+        boolean hasPlacedVillageBlocks = false;
         boolean gen = false;
 
-        MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Pre(ichunkprovider, worldObj, rand, chunkX, chunkZ, flag));
+        MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Pre(ichunkprovider, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks));
 
         if (mapFeaturesEnabled) {
 
@@ -731,15 +731,15 @@ public class ChunkProviderRTG implements IChunkProvider
                 if (ConfigRTG.villageCrashFix) {
                     
                     try {
-                        flag = villageGenerator.generateStructuresInChunk(worldObj, rand, chunkX, chunkZ);
+                        hasPlacedVillageBlocks = villageGenerator.generateStructuresInChunk(worldObj, rand, chunkX, chunkZ);
                     }
                     catch (Exception e) {
-                        flag = false;
+                        hasPlacedVillageBlocks = false;
                     }
                 }
                 else {
                     
-                    flag = villageGenerator.generateStructuresInChunk(worldObj, rand, chunkX, chunkZ);
+                    hasPlacedVillageBlocks = villageGenerator.generateStructuresInChunk(worldObj, rand, chunkX, chunkZ);
                 }
             }
 
@@ -752,7 +752,7 @@ public class ChunkProviderRTG implements IChunkProvider
         }
 
                 TimeTracker.manager.start("Pools");
-        biome.rPopulatePreDecorate(ichunkprovider, worldObj, rand, chunkX, chunkZ, flag);
+        biome.rPopulatePreDecorate(ichunkprovider, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
                 TimeTracker.manager.stop("Pools");
 
         /**
@@ -816,7 +816,7 @@ public class ChunkProviderRTG implements IChunkProvider
                  */
                 if (ConfigRTG.enableRTGBiomeDecorations && realisticBiome.config._boolean(BiomeConfig.useRTGDecorationsId)) {
 
-                	realisticBiome.decorateInAnOrderlyFashion(this.worldObj, this.rand, worldX, worldZ, simplex, cell, borderNoise[bn], river);
+                	realisticBiome.decorateInAnOrderlyFashion(this.worldObj, this.rand, worldX, worldZ, simplex, cell, borderNoise[bn], river, hasPlacedVillageBlocks);
                 }
                 else {
                     
@@ -826,7 +826,7 @@ public class ChunkProviderRTG implements IChunkProvider
                     }
                     catch (Exception e) {
 
-                    	realisticBiome.decorateInAnOrderlyFashion(this.worldObj, this.rand, worldX, worldZ, simplex, cell, borderNoise[bn], river);
+                    	realisticBiome.decorateInAnOrderlyFashion(this.worldObj, this.rand, worldX, worldZ, simplex, cell, borderNoise[bn], river, hasPlacedVillageBlocks);
                     }
                 }
 
@@ -851,7 +851,7 @@ public class ChunkProviderRTG implements IChunkProvider
          * ########################################################################
          */
         TimeTracker.manager.start("Post-decorations");
-        biome.rPopulatePostDecorate(ichunkprovider, worldObj, rand, chunkX, chunkZ, flag);
+        biome.rPopulatePostDecorate(ichunkprovider, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
         
         //Flowing water.
         if (ConfigRTG.flowingWaterChance > 0) {
@@ -884,7 +884,7 @@ public class ChunkProviderRTG implements IChunkProvider
         probe.setX(chunkX);
         probe.setZ(chunkZ);
         //if (everDecorated.contains(probe)) throw new RuntimeException();
-        if (TerrainGen.populate(this, worldObj, rand, chunkX, chunkZ, flag, PopulateChunkEvent.Populate.EventType.ANIMALS))
+        if (TerrainGen.populate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks, PopulateChunkEvent.Populate.EventType.ANIMALS))
         {
             SpawnerAnimals.performWorldGenSpawning(this.worldObj, worldObj.getBiomeGenForCoords(worldX + 16, worldZ + 16), worldX, worldZ, 16, 16, this.rand);
         }
@@ -895,7 +895,7 @@ public class ChunkProviderRTG implements IChunkProvider
         probe.setX(chunkX);
         probe.setZ(chunkZ);
         //if (!everDecorated.contains(probe)) throw new RuntimeException();
-        if (TerrainGen.populate(this, worldObj, rand, chunkX, chunkZ, flag, PopulateChunkEvent.Populate.EventType.ICE)) {
+        if (TerrainGen.populate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks, PopulateChunkEvent.Populate.EventType.ICE)) {
 
             int k1, l1, i2;
             
@@ -919,7 +919,7 @@ public class ChunkProviderRTG implements IChunkProvider
         }
         TimeTracker.manager.stop("Ice");
 
-        MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Post(ichunkprovider, worldObj, rand, chunkX, chunkZ, flag));
+        MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Post(ichunkprovider, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks));
 
         BlockFalling.fallInstantly = false;
         TimeTracker.manager.stop("RTG populate");


### PR DESCRIPTION
This is the stuff I've done so far on the village-aware decos.

The village flag has been renamed to `hasPlacedVillageBlocks`, and it is now being passed to all decos. However, only trees, shrubs, logs, and boulders are utilizing it, since they're the most troublesome ones in villages.

I'm putting this up for review because @Zeno410 mentioned something about implementing a village cache of some sort and just want to make sure this stuff is going to be compatible with it, or if it's even necessary at all with the village cache.

Here are some before & after screenshots (sorry, the angles aren't exactly lined up):

![village-1](https://cloud.githubusercontent.com/assets/10927161/16332370/7d201c14-39ed-11e6-81f0-dc9132f6be1e.gif)

![village-2](https://cloud.githubusercontent.com/assets/10927161/16332371/7d21ff52-39ed-11e6-8c1d-d2a595b4934f.gif)

![village-3](https://cloud.githubusercontent.com/assets/10927161/16332369/7d1f7994-39ed-11e6-8e86-37693e06a958.gif)
