### PR TITLE
Minestrappolation support

### DIFF
--- a/etc/config/RTG/biomes/minestrappolation.cfg
+++ b/etc/config/RTG/biomes/minestrappolation.cfg
@@ -1,0 +1,66 @@
+# Configuration file
+
+biome {
+
+    minestrappolation {
+
+        redwoodforest {
+            #  [default: true]
+            B:"Allow Villages"=true
+
+            #  [default: true]
+            B:"RTG Decoration: Logs"=true
+
+            #  [default: ]
+            S:"RTG Surface: Filler Block"=
+
+            #  [default: ]
+            S:"RTG Surface: Filler Block Meta"=
+
+            #  [default: ]
+            S:"RTG Surface: Mix Block"=
+
+            #  [default: ]
+            S:"RTG Surface: Mix Block Meta"=
+
+            #  [default: ]
+            S:"RTG Surface: Top Block"=
+
+            #  [default: ]
+            S:"RTG Surface: Top Block Meta"=
+
+            #  [default: true]
+            B:"Use RTG Decorations"=true
+
+            #  [default: true]
+            B:"Use RTG Surfaces"=true
+        }
+
+        thefrost {
+            #  [default: true]
+            B:"Allow Villages"=true
+
+            #  [default: ]
+            S:"RTG Surface: Filler Block"=
+
+            #  [default: ]
+            S:"RTG Surface: Filler Block Meta"=
+
+            #  [default: ]
+            S:"RTG Surface: Top Block"=
+
+            #  [default: ]
+            S:"RTG Surface: Top Block Meta"=
+
+            #  [default: true]
+            B:"Use RTG Decorations"=true
+
+            #  [default: true]
+            B:"Use RTG Surfaces"=true
+        }
+
+    }
+
+}
+
+

--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -1,11 +1,25 @@
 package rtg;
 
+import static rtg.reference.ModInfo.FORGE_DEP;
+import static rtg.reference.ModInfo.MOD_ID;
+import static rtg.reference.ModInfo.MOD_NAME;
+import static rtg.reference.ModInfo.MOD_VERSION;
+
+import java.util.ArrayList;
+
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.*;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerAboutToStartEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import rtg.api.event.BiomeConfigEvent;
 import rtg.config.BiomeConfigManager;
@@ -19,10 +33,9 @@ import rtg.world.WorldTypeRTG;
 import rtg.world.biome.realistic.abyssalcraft.RealisticBiomeACBase;
 import rtg.world.biome.realistic.biomesoplenty.RealisticBiomeBOPBase;
 import rtg.world.biome.realistic.buildcraft.RealisticBiomeBCBase;
+import rtg.world.biome.realistic.minestrappolation.RealisticBiomeMSBase;
 import rtg.world.biome.realistic.thaumcraft.RealisticBiomeTCBase;
 import rtg.world.biome.realistic.vanilla.RealisticBiomeVanillaBase;
-import java.util.ArrayList;
-import static rtg.reference.ModInfo.*;
 
 @Mod(modid = MOD_ID, name = MOD_NAME, version = MOD_VERSION, dependencies = "required-after:Forge@[" + FORGE_DEP + ",)", acceptableRemoteVersions = "*")
 public class RTG {
@@ -90,6 +103,7 @@ public class RTG {
 //        RealisticBiomeGCBase.addBiomes();
 //        RealisticBiomeVAMPBase.addBiomes();
         RealisticBiomeACBase.addBiomes();
+        RealisticBiomeMSBase.addBiomes();
 //        RealisticBiomeRWBase.addBiomes();
 //        RealisticBiomeLOMBase.addBiomes();
 //        RealisticBiomeTOFUBase.addBiomes();

--- a/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMS.java
+++ b/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMS.java
@@ -1,0 +1,20 @@
+package rtg.api.biome.minestrappolation.config;
+
+import rtg.api.biome.BiomeConfig;
+
+public class BiomeConfigMS
+{
+
+    public static BiomeConfig biomeConfigMSRedwoodForest;
+    public static BiomeConfig biomeConfigMSTheFrost;
+    
+    public static BiomeConfig[] getBiomeConfigs()
+    {
+        BiomeConfig[] biomeConfigs = new BiomeConfig[]{
+        	biomeConfigMSRedwoodForest,
+            biomeConfigMSTheFrost
+        };
+        
+        return biomeConfigs;
+    }
+}

--- a/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSBase.java
+++ b/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSBase.java
@@ -1,0 +1,12 @@
+package rtg.api.biome.minestrappolation.config;
+
+import rtg.api.biome.BiomeConfig;
+
+public class BiomeConfigMSBase extends BiomeConfig
+{
+
+    public BiomeConfigMSBase(String biomeSlug)
+    {
+        super("minestrappolation", biomeSlug);
+    }
+}

--- a/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSRedwoodForest.java
+++ b/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSRedwoodForest.java
@@ -1,0 +1,28 @@
+package rtg.api.biome.minestrappolation.config;
+
+import rtg.api.biome.BiomeConfigProperty;
+import rtg.api.biome.BiomeConfigProperty.Type;
+
+
+public class BiomeConfigMSRedwoodForest extends BiomeConfigMSBase
+{
+
+    public static final String decorationLogsId = "decorationLogs";
+    public static final String decorationLogsName = "RTG Decoration: Logs";
+    
+    public static final String surfaceMixBlockId = "surfaceMixBlock";
+    public static final String surfaceMixBlockName = "RTG Surface: Mix Block";
+    
+    public static final String surfaceMixBlockMetaId = "surfaceMixBlockMeta";
+    public static final String surfaceMixBlockMetaName = "RTG Surface: Mix Block Meta";   
+    
+    public BiomeConfigMSRedwoodForest()
+    {
+        super("redwoodforest");
+        
+        this.addProperty(new BiomeConfigProperty(decorationLogsId, Type.BOOLEAN, decorationLogsName, "", true));
+        
+        this.addProperty(new BiomeConfigProperty(surfaceMixBlockId, Type.STRING, surfaceMixBlockName, "", ""));
+        this.addProperty(new BiomeConfigProperty(surfaceMixBlockMetaId, Type.STRING, surfaceMixBlockMetaName, "", ""));
+    }
+}

--- a/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSTheFrost.java
+++ b/src/main/java/rtg/api/biome/minestrappolation/config/BiomeConfigMSTheFrost.java
@@ -1,0 +1,10 @@
+package rtg.api.biome.minestrappolation.config;
+
+
+public class BiomeConfigMSTheFrost extends BiomeConfigMSBase
+{
+    public BiomeConfigMSTheFrost()
+    {
+        super("thefrost");
+    }
+}

--- a/src/main/java/rtg/config/BiomeConfigManager.java
+++ b/src/main/java/rtg/config/BiomeConfigManager.java
@@ -78,6 +78,9 @@ import rtg.api.biome.biomesoplenty.config.BiomeConfigBOPXericShrubland;
 import rtg.api.biome.buildcraft.config.BiomeConfigBC;
 import rtg.api.biome.buildcraft.config.BiomeConfigBCDesertOilField;
 import rtg.api.biome.buildcraft.config.BiomeConfigBCOceanOilField;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMS;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMSRedwoodForest;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMSTheFrost;
 import rtg.api.biome.thaumcraft.config.BiomeConfigTC;
 import rtg.api.biome.thaumcraft.config.BiomeConfigTCEerie;
 import rtg.api.biome.thaumcraft.config.BiomeConfigTCMagicalForest;
@@ -151,6 +154,7 @@ public class BiomeConfigManager
         initBiomeConfigsAC();
         initBiomeConfigsBOP();
         initBiomeConfigsBC();
+        initBiomeConfigsMS();
         initBiomeConfigsTC();
         initBiomeConfigsVanilla();
     }
@@ -235,6 +239,12 @@ public class BiomeConfigManager
     {
         BiomeConfigBC.biomeConfigBCDesertOilField = new BiomeConfigBCDesertOilField();
         BiomeConfigBC.biomeConfigBCOceanOilField = new BiomeConfigBCOceanOilField();
+    }
+    
+    public static void initBiomeConfigsMS()
+    {
+        BiomeConfigMS.biomeConfigMSRedwoodForest = new BiomeConfigMSRedwoodForest();
+        BiomeConfigMS.biomeConfigMSTheFrost = new BiomeConfigMSTheFrost();
     }
 
     public static void initBiomeConfigsTC()

--- a/src/main/java/rtg/config/ConfigManager.java
+++ b/src/main/java/rtg/config/ConfigManager.java
@@ -5,6 +5,7 @@ import java.io.File;
 import rtg.config.abyssalcraft.ConfigAC;
 import rtg.config.biomesoplenty.ConfigBOP;
 import rtg.config.buildcraft.ConfigBC;
+import rtg.config.minestrappolation.ConfigMS;
 import rtg.config.rtg.ConfigRTG;
 import rtg.config.thaumcraft.ConfigTC;
 import rtg.config.vanilla.ConfigVanilla;
@@ -18,6 +19,7 @@ public class ConfigManager
     public static File tcConfigFile;
     public static File bcConfigFile;
     public static File acConfigFile;
+    public static File msConfigFile;
 
     private ConfigRTG configRTG = new ConfigRTG();
     public ConfigRTG rtg() {
@@ -33,6 +35,7 @@ public class ConfigManager
         tcConfigFile = new File(configpath + "biomes/thaumcraft.cfg");
         bcConfigFile = new File(configpath + "biomes/buildcraft.cfg");
         acConfigFile = new File(configpath + "biomes/abyssalcraft.cfg");
+        msConfigFile = new File(configpath + "biomes/minestrappolation.cfg");
         
         ConfigRTG.init(rtgConfigFile);
 
@@ -42,5 +45,6 @@ public class ConfigManager
         ConfigTC.init(tcConfigFile);
         ConfigBC.init(bcConfigFile);
         ConfigAC.init(acConfigFile);
+        ConfigMS.init(msConfigFile);
     }
 }

--- a/src/main/java/rtg/config/minestrappolation/ConfigMS.java
+++ b/src/main/java/rtg/config/minestrappolation/ConfigMS.java
@@ -1,0 +1,36 @@
+package rtg.config.minestrappolation;
+
+import java.io.File;
+
+import net.minecraftforge.common.config.Configuration;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMS;
+import rtg.config.BiomeConfigManager;
+import rtg.util.Logger;
+
+public class ConfigMS
+{
+    public static Configuration config;
+
+    public static void init(File configFile)
+    {
+    
+        config = new Configuration(configFile);
+        
+        try
+        {
+            config.load();
+            
+            BiomeConfigManager.setBiomeConfigsFromUserConfigs(BiomeConfigMS.getBiomeConfigs(), config);
+            
+        } catch (Exception e)
+        {
+            Logger.error("RTG has had a problem loading Minestrappolation configuration.");
+        } finally
+        {
+            if (config.hasChanged())
+            {
+                config.save();
+            }
+        }
+    }
+}

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -1,5 +1,9 @@
 package rtg.world.biome.realistic;
 
+import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY;
+
+import java.util.Random;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockStone;
 import net.minecraft.block.state.pattern.BlockHelper;
@@ -28,10 +32,6 @@ import rtg.world.gen.feature.WorldGenClay;
 import rtg.world.gen.surface.SurfaceBase;
 import rtg.world.gen.surface.SurfaceGeneric;
 import rtg.world.gen.terrain.TerrainBase;
-
-import java.util.Random;
-
-import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY;
 
 public class RealisticBiomeBase extends BiomeBase {
     

--- a/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSBase.java
+++ b/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSBase.java
@@ -1,0 +1,57 @@
+package rtg.world.biome.realistic.minestrappolation;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.fml.common.Loader;
+import rtg.api.biome.BiomeConfig;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMS;
+import rtg.util.Logger;
+import rtg.world.biome.realistic.RealisticBiomeBase;
+import rtg.world.gen.surface.SurfaceBase;
+import rtg.world.gen.terrain.TerrainBase;
+
+public class RealisticBiomeMSBase extends RealisticBiomeBase
+{
+
+    public static RealisticBiomeBase msRedwoodForest;
+    public static RealisticBiomeBase msTheFrost;
+
+    public RealisticBiomeMSBase(BiomeConfig config, BiomeGenBase b, BiomeGenBase riverbiome, TerrainBase t, SurfaceBase s)
+    {
+        super(config, b, riverbiome, t, s);
+        
+        this.waterSurfaceLakeChance = 0;
+        this.lavaSurfaceLakeChance = 0;
+    }
+    
+    public static void addBiomes()
+    {
+        if (Loader.isModLoaded("ministrapp"))
+        {
+            BiomeGenBase[] b = BiomeGenBase.getBiomeGenArray();
+            
+            for (int i = 0; i < 256; i++)
+            {
+                if (b[i] != null)
+                {
+                    if (b[i].biomeName == null) {
+                        Logger.warn("Biome ID %d has no name.", b[i].biomeID);
+                        continue;
+                    }
+                    
+                    BiomeGenBase msBiome = b[i];
+                    String biomeName = b[i].biomeName;
+                    String biomeClass = b[i].getBiomeClass().getName();
+                    
+                    if (biomeName == "Redwood Forest" && biomeClass == "minestrapteam.mods.minestrappolation.world.biomes.BiomeRedwood")
+                    {
+                    	msRedwoodForest = new RealisticBiomeMSRedwoodForest(msBiome, BiomeConfigMS.biomeConfigMSRedwoodForest);
+                    }
+                    else if (biomeName == "The Frost" && biomeClass == "minestrapteam.mods.minestrappolation.world.biomes.BiomeFrost")
+                    {
+                    	msTheFrost = new RealisticBiomeMSTheFrost(msBiome, BiomeConfigMS.biomeConfigMSTheFrost);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSRedwoodForest.java
+++ b/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSRedwoodForest.java
@@ -1,0 +1,80 @@
+package rtg.world.biome.realistic.minestrappolation;
+
+import java.util.Random;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import rtg.api.biome.BiomeConfig;
+import rtg.api.biome.minestrappolation.config.BiomeConfigMSRedwoodForest;
+import rtg.util.CellNoise;
+import rtg.util.OpenSimplexNoise;
+import rtg.world.gen.feature.WorldGenGrass;
+import rtg.world.gen.feature.WorldGenLog;
+import rtg.world.gen.feature.tree.WorldGenTreeRTGShrubCustom;
+import rtg.world.gen.surface.minestrappolation.SurfaceMSRedwoodForest;
+import rtg.world.gen.terrain.minestrappolation.TerrainMSRedwoodForest;
+
+public class RealisticBiomeMSRedwoodForest extends RealisticBiomeMSBase
+{
+
+    public RealisticBiomeMSRedwoodForest(BiomeGenBase msBiome, BiomeConfig config)
+    {
+    
+        super(config, 
+            msBiome,
+            BiomeGenBase.river,
+            new TerrainMSRedwoodForest(),
+            new SurfaceMSRedwoodForest(config, msBiome.topBlock, msBiome.fillerBlock, false, null, 0f, 1.5f, 60f, 65f, 1.5f, msBiome.topBlock, 0.10f));
+    }
+    
+    @Override
+    public void rDecorate(World world, Random rand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float strength, float river)
+    {
+        
+        /**
+         * Using rDecorateSeedBiome() to partially decorate the biome? If so, then comment out this method.
+         */
+        //rOreGenSeedBiome(world, rand, chunkX, chunkY, simplex, cell, strength, river, baseBiome);
+    
+        float l = simplex.noise2(chunkX / 80f, chunkY / 80f) * 60f - 15f;
+        
+        if (this.config.getPropertyById(BiomeConfigMSRedwoodForest.decorationLogsId).valueBoolean) {
+        
+            if (rand.nextInt((int) (10f / strength)) == 0)
+            {
+                int x22 = chunkX + rand.nextInt(16) + 8;
+                int z22 = chunkY + rand.nextInt(16) + 8;
+                int y22 = world.getHeight(new BlockPos(x22,0, z22)).getY();
+                
+                if (y22 < 100)
+                {
+                    (new WorldGenLog(Blocks.log, 0, Blocks.leaves, -1, 2 + rand.nextInt(2))).generate(world, rand, x22, y22, z22);
+                }
+            }
+        }
+        
+        for (int f24 = 0; f24 < 3f * strength; f24++)
+        {
+            int i1 = chunkX + rand.nextInt(16) + 8;
+            int j1 = chunkY + rand.nextInt(16) + 8;
+            int k1 = world.getHeight(new BlockPos(i1, 0,j1)).getY();
+            
+            if (k1 < 110 && rand.nextInt(3) != 0)
+            {
+                (new WorldGenTreeRTGShrubCustom(rand.nextInt(4) + 1, Blocks.log, (byte)0, Blocks.leaves, (byte)0)).generate(world, rand, i1, k1, j1);
+            }
+        }
+        
+        for (int l14 = 0; l14 < 8f * strength; l14++)
+        {
+            int l19 = chunkX + rand.nextInt(16) + 8;
+            int k22 = rand.nextInt(128);
+            int j24 = chunkY + rand.nextInt(16) + 8;
+            (new WorldGenGrass(Blocks.tallgrass, 1)).generate(world, rand, l19, k22, j24);
+        }
+        
+        rDecorateSeedBiome(world, rand, chunkX, chunkY, simplex, cell, strength, river, baseBiome);
+    }
+}

--- a/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSTheFrost.java
+++ b/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSTheFrost.java
@@ -13,7 +13,7 @@ public class RealisticBiomeMSTheFrost extends RealisticBiomeMSBase
     
         super(config, 
             msBiome,
-            BiomeGenBase.river,
+            BiomeGenBase.frozenRiver,
             new TerrainMSTheFrost(),
             new SurfaceMSTheFrost(config, msBiome.topBlock, msBiome.fillerBlock));
     }

--- a/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSTheFrost.java
+++ b/src/main/java/rtg/world/biome/realistic/minestrappolation/RealisticBiomeMSTheFrost.java
@@ -1,0 +1,20 @@
+package rtg.world.biome.realistic.minestrappolation;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import rtg.api.biome.BiomeConfig;
+import rtg.world.gen.surface.minestrappolation.SurfaceMSTheFrost;
+import rtg.world.gen.terrain.minestrappolation.TerrainMSTheFrost;
+
+public class RealisticBiomeMSTheFrost extends RealisticBiomeMSBase
+{
+
+    public RealisticBiomeMSTheFrost(BiomeGenBase msBiome, BiomeConfig config)
+    {
+    
+        super(config, 
+            msBiome,
+            BiomeGenBase.river,
+            new TerrainMSTheFrost(),
+            new SurfaceMSTheFrost(config, msBiome.topBlock, msBiome.fillerBlock));
+    }
+}

--- a/src/main/java/rtg/world/gen/surface/minestrappolation/SurfaceMSRedwoodForest.java
+++ b/src/main/java/rtg/world/gen/surface/minestrappolation/SurfaceMSRedwoodForest.java
@@ -1,0 +1,160 @@
+package rtg.world.gen.surface.minestrappolation;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.ChunkPrimer;
+import rtg.api.biome.BiomeConfig;
+import rtg.api.biome.vanilla.config.BiomeConfigVanillaForest;
+import rtg.util.CellNoise;
+import rtg.util.CliffCalculator;
+import rtg.util.OpenSimplexNoise;
+import rtg.world.gen.surface.SurfaceBase;
+
+public class SurfaceMSRedwoodForest extends SurfaceBase
+{
+    
+    private boolean beach;
+    private IBlockState beachBlock;
+    private float min;
+    
+    private float sCliff = 1.5f;
+    private float sHeight = 60f;
+    private float sStrength = 65f;
+    private float cCliff = 1.5f;
+    
+    private IBlockState mixBlock;
+    private float mixHeight;
+        
+    public SurfaceMSRedwoodForest(BiomeConfig config, IBlockState top, IBlockState fill, boolean genBeach, IBlockState genBeachBlock, float minCliff, float stoneCliff,
+        float stoneHeight, float stoneStrength, float clayCliff, IBlockState mix, float mixSize)
+    {
+    
+        super(config, top, fill);
+        beach = genBeach;
+        beachBlock = genBeachBlock;
+        min = minCliff;
+        
+        sCliff = stoneCliff;
+        sHeight = stoneHeight;
+        sStrength = stoneStrength;
+        cCliff = clayCliff;
+        
+        mixBlock = this.getConfigBlock(config, BiomeConfigVanillaForest.surfaceMixBlockId, BiomeConfigVanillaForest.surfaceMixBlockMetaId, mix);
+        mixHeight = mixSize;
+    }
+    
+    @Override
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int y, int depth, World world, Random rand,
+                             OpenSimplexNoise simplex, CellNoise cell, float[] noise, float river, BiomeGenBase[] base)
+    {
+    
+        float c = CliffCalculator.calc(x, y, noise);
+        int cliff = 0;
+        boolean gravel = false;
+        boolean m = false;
+        
+        Block b;
+        for (int k = 255; k > -1; k--)
+        {
+            b = primer.getBlockState((y * 16 + x) * 256 + k).getBlock();
+            if (b == Blocks.air)
+            {
+                depth = -1;
+            }
+            else if (b == Blocks.stone)
+            {
+                depth++;
+                
+                if (depth == 0)
+                {
+                    if (k < 63)
+                    {
+                        if (beach)
+                        {
+                            gravel = true;
+                        }
+                    }
+                    
+                    float p = simplex.noise3(i / 8f, j / 8f, k / 8f) * 0.5f;
+                    if (c > min && c > sCliff - ((k - sHeight) / sStrength) + p)
+                    {
+                        cliff = 1;
+                    }
+                    if (c > cCliff)
+                    {
+                        cliff = 2;
+                    }
+                    
+                    if (cliff == 1)
+                    {
+                        if (rand.nextInt(3) == 0) {
+                            
+                            primer.setBlockState((y * 16 + x) * 256 + k,hcCobble(world, i, j, x, y, k));
+                        }
+                        else {
+                            
+                            primer.setBlockState((y * 16 + x) * 256 + k,hcStone(world, i, j, x, y, k));
+                        }
+                    }
+                    else if (cliff == 2)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,getShadowStoneBlock(world, i, j, x, y, k));
+                    }
+                    else if (k < 63)
+                    {
+                        if (beach)
+                        {
+                            primer.setBlockState((y * 16 + x) * 256 + k, beachBlock);
+                            gravel = true;
+                        }
+                        else if (k < 62)
+                        {
+                            primer.setBlockState((y * 16 + x) * 256 + k,fillerBlock);
+                        }
+                        else
+                        {
+                            primer.setBlockState((y * 16 + x) * 256 + k,topBlock);
+                        }
+                    }
+                    else if (simplex.noise2(i / 12f, j / 12f) > mixHeight)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,mixBlock);
+                        m = true;
+                    }
+                    else
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,topBlock);
+                    }
+                }
+                else if (depth < 6)
+                {
+                    if (cliff == 1)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,hcStone(world, i, j, x, y, k));
+                    }
+                    else if (cliff == 2)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,getShadowStoneBlock(world, i, j, x, y, k));
+                    }
+                    else if (gravel)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k, beachBlock);
+                    }
+                    else if (m)
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,mixBlock);
+                    }
+                    else
+                    {
+                        primer.setBlockState((y * 16 + x) * 256 + k,fillerBlock);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/rtg/world/gen/surface/minestrappolation/SurfaceMSTheFrost.java
+++ b/src/main/java/rtg/world/gen/surface/minestrappolation/SurfaceMSTheFrost.java
@@ -1,0 +1,74 @@
+package rtg.world.gen.surface.minestrappolation;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.ChunkPrimer;
+import rtg.api.biome.BiomeConfig;
+import rtg.util.CellNoise;
+import rtg.util.CliffCalculator;
+import rtg.util.OpenSimplexNoise;
+import rtg.world.gen.surface.SurfaceBase;
+
+public class SurfaceMSTheFrost extends SurfaceBase
+{
+    
+	public SurfaceMSTheFrost(BiomeConfig config, IBlockState top, IBlockState filler)
+	{
+		super(config, top, filler);
+	}
+	
+	@Override
+	public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int y, int depth, World world, Random rand, OpenSimplexNoise simplex, CellNoise cell, float[] noise, float river, BiomeGenBase[] base)
+	{
+		float c = CliffCalculator.calc(x, y, noise);
+		boolean cliff = c > 1.4f ? true : false;
+		
+		for(int k = 255; k > -1; k--)
+		{
+			Block b = primer.getBlockState((y * 16 + x) * 256 + k).getBlock();
+            if(b == Blocks.air)
+            {
+            	depth = -1;
+            }
+            else if(b == Blocks.stone)
+            {
+            	depth++;
+
+            	if(cliff)
+            	{
+            		if(depth > -1 && depth < 2)
+            		{
+                        if (rand.nextInt(3) == 0) {
+                            
+                            primer.setBlockState((y * 16 + x) * 256 + k,hcCobble(world, i, j, x, y, k));
+                        }
+                        else {
+                            
+                            primer.setBlockState((y * 16 + x) * 256 + k,hcStone(world, i, j, x, y, k));
+                        }
+            		}
+            		else if (depth < 10)
+            		{
+                        primer.setBlockState((y * 16 + x) * 256 + k,hcStone(world, i, j, x, y, k));
+            		}
+            	}
+            	else
+            	{
+	        		if(depth == 0 && k > 61)
+	        		{
+	        			primer.setBlockState((y * 16 + x) * 256 + k,topBlock);
+	        		}
+	        		else if(depth < 4)
+	        		{
+	        			primer.setBlockState((y * 16 + x) * 256 + k,fillerBlock);
+	        		}
+            	}
+            }
+		}
+	}
+}

--- a/src/main/java/rtg/world/gen/terrain/minestrappolation/TerrainMSRedwoodForest.java
+++ b/src/main/java/rtg/world/gen/terrain/minestrappolation/TerrainMSRedwoodForest.java
@@ -1,0 +1,20 @@
+package rtg.world.gen.terrain.minestrappolation;
+
+import rtg.util.CellNoise;
+import rtg.util.OpenSimplexNoise;
+import rtg.world.gen.terrain.TerrainBase;
+
+public class TerrainMSRedwoodForest extends TerrainBase
+{
+
+    public TerrainMSRedwoodForest()
+    {
+
+    }
+
+    @Override
+    public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
+    {
+        return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 80f, 68f);
+    }
+}

--- a/src/main/java/rtg/world/gen/terrain/minestrappolation/TerrainMSTheFrost.java
+++ b/src/main/java/rtg/world/gen/terrain/minestrappolation/TerrainMSTheFrost.java
@@ -1,0 +1,20 @@
+package rtg.world.gen.terrain.minestrappolation;
+
+import rtg.util.CellNoise;
+import rtg.util.OpenSimplexNoise;
+import rtg.world.gen.terrain.TerrainBase;
+
+public class TerrainMSTheFrost extends TerrainBase
+{
+
+    public TerrainMSTheFrost()
+    {
+
+    }
+
+    @Override
+    public float generateNoise(OpenSimplexNoise simplex, CellNoise cell, int x, int y, float border, float river)
+    {
+        return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
+    }
+}


### PR DESCRIPTION
Putting this up for review to demonstrate the version branch workflow in case it wasn't obvious from #784. Also, whilst I'm pretty sure the 'one repo' approach is the way to go, the only way to really know for sure is to try it out and see if it falls down anywhere.

As for the PR itself, so far this only adds biome support for Minestrappolation (Redwood Forest & The Frost). The person who requested this [in the forums](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2524489-realistic-terrain-generation-rtg-realistic-biomes?comment=2025) mentioned that a lot of world gen wasn't being generated, including MS ores, and I know why:

https://github.com/MinestrapTeam/Minestrappolation-4/blob/master/src/main/java/minestrapteam/mods/minestrappolation/world/MGenHandler.java#L120-L187

Our old friend, the biome comparison check (`biome == BiomeGenBase.xxxxx`)  :/

So whilst we could add biome support for Minestrappolation (either with the manual approach in the PR, or the welding approach from v2), we won't be able to fully support Minestrappolation until those biome comparisons checks are replaced with biome ID checks.
