### PR TITLE
Fallen tree tweaks

### DIFF
--- a/src/main/java/teamrtg/rtg/api/tools/deco/DecoBoulder.java
+++ b/src/main/java/teamrtg/rtg/api/tools/deco/DecoBoulder.java
@@ -53,7 +53,7 @@ public class DecoBoulder extends DecoBase
 	{
 		if (this.allowed) {
 			
-			WorldUtil worldUtil = new WorldUtil(rtgWorld);
+			WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
 			WorldGenerator worldGenerator = new WorldGenBlob(boulderBlock, 0, rand, this.water);
 			
             for (int l1 = 0; l1 < this.strengthFactor * strength; ++l1)

--- a/src/main/java/teamrtg/rtg/api/tools/deco/DecoFallenTree.java
+++ b/src/main/java/teamrtg/rtg/api/tools/deco/DecoFallenTree.java
@@ -89,7 +89,7 @@ public class DecoFallenTree extends DecoBase
 		if (this.allowed) {
 
 			float noise = rtgWorld.simplex.noise2(chunkX / this.distribution.noiseDivisor, chunkY / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
-			WorldUtil worldUtil = new WorldUtil(rtgWorld);
+			WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
 			
 			//Do we want to choose a random log?
 			if (this.useRandomLogs) {

--- a/src/main/java/teamrtg/rtg/api/tools/deco/DecoShrub.java
+++ b/src/main/java/teamrtg/rtg/api/tools/deco/DecoShrub.java
@@ -90,7 +90,7 @@ public class DecoShrub extends DecoBase
         		this.leavesBlock = this.randomLeavesBlocks[rnd];
             }
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
             WorldGenerator worldGenerator = new WorldGenShrubRTG(this.size, this.logBlock, this.leavesBlock);
             
 			int loopCount = this.loops;

--- a/src/main/java/teamrtg/rtg/api/tools/deco/DecoTree.java
+++ b/src/main/java/teamrtg/rtg/api/tools/deco/DecoTree.java
@@ -135,7 +135,7 @@ public class DecoTree extends DecoBase
 			
 			if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(chunkX, 0, chunkY), TREE)) {
 				
-				WorldUtil worldUtil = new WorldUtil(rtgWorld);
+				WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
 				float noise = rtgWorld.simplex.noise2(chunkX / this.distribution.noiseDivisor, chunkY / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
 
                 int loopCount = this.loops;

--- a/src/main/java/teamrtg/rtg/api/tools/feature/WorldGenLog.java
+++ b/src/main/java/teamrtg/rtg/api/tools/feature/WorldGenLog.java
@@ -10,14 +10,17 @@ import static net.minecraft.block.material.Material.VINE;
 import static net.minecraft.block.material.Material.WATER;
 import static net.minecraft.init.Blocks.LOG2;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
+import teamrtg.rtg.api.util.WorldUtil;
 
 public class WorldGenLog extends WorldGenerator {
     private int logMeta;
@@ -55,11 +58,13 @@ public class WorldGenLog extends WorldGenerator {
     }
 
     public boolean generate(World world, Random rand, int x, int y, int z) {
+    	
         Block g = world.getBlockState(new BlockPos(x, y - 1, z)).getBlock();
         if (g.getMaterial(g.getDefaultState()) != GROUND && g.getMaterial(g.getDefaultState()) != GRASS && g.getMaterial(g.getDefaultState()) != SAND && g.getMaterial(g.getDefaultState()) != ROCK) {
             return false;
         }
 
+        WorldUtil worldUtil = new WorldUtil(world);
         int dir = rand.nextInt(2);
         int dirMeta = 4 + (dir * 4) + logMeta;
         boolean LEAVES = leavesMeta > -1;
@@ -81,6 +86,8 @@ public class WorldGenLog extends WorldGenerator {
             }
         }
 
+        ArrayList<BlockPos> aBlockPos = new ArrayList<BlockPos>();
+        ArrayList<IBlockState> aBlockState = new ArrayList<IBlockState>();
         for (i = 0; i < logLength * 2; i++) {
             b = world.getBlockState(new BlockPos(x + (dir == 0 ? 1 : 0), y, z + (dir == 1 ? 1 : 0))).getBlock();
             if (b.getMaterial(b.getDefaultState()) != Material.AIR && b.getMaterial(b.getDefaultState()) != VINE && b.getMaterial(b.getDefaultState()) != PLANTS) {
@@ -92,7 +99,21 @@ public class WorldGenLog extends WorldGenerator {
                 return false;
             }
 
-            world.setBlockState(new BlockPos(x, y, z), logBlock.getStateFromMeta(dirMeta), 0);
+            /**
+             * Before we place the log block, let's make sure that there's an air block immediately above it.
+             * This is to ensure that the log doesn't override, for example, a 2-block tall plant,
+             * which some mods (like WAILA) have trouble handling.
+             * 
+             * Also, to ensure that we don't have 'broken' logs, if one log block fails the check,
+             * then no logs actually get placed.
+             */
+            if (!worldUtil.isBlockAbove(Blocks.AIR.getDefaultState(), 1, world, x, y, z, true)) {
+            	return false;
+            }
+            
+            // Store the log information instead of placing it straight away.
+            aBlockPos.add(new BlockPos(x, y, z));
+            aBlockState.add(logBlock.getStateFromMeta(dirMeta));
 
             if (leavesMeta > -1) {
                 addLeaves(world, rand, dir, x, y, z);
@@ -101,7 +122,11 @@ public class WorldGenLog extends WorldGenerator {
             x += dir == 0 ? 1 : 0;
             z += dir == 1 ? 1 : 0;
         }
-
+        
+        for (int i1 = 0; i1 < aBlockPos.size(); i1++) {
+        	world.setBlockState(aBlockPos.get(i1), aBlockState.get(i1), 2);
+        }
+        
         return true;
     }
 

--- a/src/main/java/teamrtg/rtg/api/util/WorldUtil.java
+++ b/src/main/java/teamrtg/rtg/api/util/WorldUtil.java
@@ -2,6 +2,7 @@ package teamrtg.rtg.api.util;
 
 import java.util.Random;
 
+import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -66,6 +67,33 @@ public class WorldUtil
 		
 		return true;
 	}
+	
+	/**
+	 * Checks to see if a given block is above a given coordinate.
+	 */
+    public boolean isBlockAbove(IBlockState checkBlock, int checkDistance, World world, int x, int y, int z, boolean materialCheck)
+    {
+    	Material checkBlockMaterial = checkBlock.getBlock().getMaterial(checkBlock);
+    	IBlockState blockAbove;
+    	Material m;
+    	
+    	for (int i = 1; i <= checkDistance; i++) {
+    		
+	    	blockAbove = world.getBlockState(new BlockPos(x, y + checkDistance, z));
+	    	
+	    	if (materialCheck) {
+	    		m = blockAbove.getBlock().getMaterial(blockAbove);
+	    		if (m != checkBlockMaterial) {
+	    			return false;
+	    		}
+	    	}
+	    	else if (blockAbove != checkBlock) {
+	    		return false;
+	    	}
+    	}
+    	
+    	return true;
+    }
 	
 	public enum SurroundCheckType
 	{

--- a/src/main/java/teamrtg/rtg/api/util/WorldUtil.java
+++ b/src/main/java/teamrtg/rtg/api/util/WorldUtil.java
@@ -4,15 +4,15 @@ import java.util.Random;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
-import teamrtg.rtg.api.world.RTGWorld;
+import net.minecraft.world.World;
 
 public class WorldUtil
 {
-	private RTGWorld rtgWorld;
+	private World world;
 	
-	public WorldUtil(RTGWorld rtgWorld)
+	public WorldUtil(World world)
 	{
-		this.rtgWorld = rtgWorld;
+		this.world = world;
 	}
 	
 	/**
@@ -30,7 +30,7 @@ public class WorldUtil
 						
 						if (x == ix && z == iz) continue;
 						
-						if (this.rtgWorld.world.getBlockState(new BlockPos(x + ix, y, z + iz)) != checkBlock) return false;
+						if (this.world.getBlockState(new BlockPos(x + ix, y, z + iz)) != checkBlock) return false;
 					}
 				}
 
@@ -40,10 +40,10 @@ public class WorldUtil
 				
 				for (int i = checkDistance; i > 0; i--) {
 					
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x, y, z + i)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x, y, z - i)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x + i, y, z)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x - i, y, z)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x, y, z + i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x, y, z - i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x + i, y, z)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x - i, y, z)) != checkBlock) return false;
 				}
 				
 				break;
@@ -52,10 +52,10 @@ public class WorldUtil
 				
 				for (int i = checkDistance; i > 0; i--) {
 					
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x + i, y, z + i)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x + i, y, z - i)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x - i, y, z + i)) != checkBlock) return false;
-					if (this.rtgWorld.world.getBlockState(new BlockPos(x - i, y, z - i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x + i, y, z + i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x + i, y, z - i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x - i, y, z + i)) != checkBlock) return false;
+					if (this.world.getBlockState(new BlockPos(x - i, y, z - i)) != checkBlock) return false;
 				}
 				
 				break;


### PR DESCRIPTION
Before fallen trees are generated, we make sure that there are air blocks immediately above it. This is to ensure that the log doesn't override, for example, a 2-block tall plant, which some mods (like WAILA) have trouble handling.
