### PR TITLE
Tweaked the event management system.

### DIFF
--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -6,6 +6,13 @@ import net.minecraft.world.gen.structure.MapGenStructureIO;
 
 import net.minecraftforge.common.MinecraftForge;
 
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.Mod.Instance;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.event.FMLServerStoppedEvent;
+
 import rtg.api.event.BiomeConfigEvent;
 import rtg.config.BiomeConfigManager;
 import rtg.config.ConfigManager;
@@ -36,13 +43,6 @@ import rtg.world.biome.realistic.vampirism.RealisticBiomeVAMPBase;
 import rtg.world.biome.realistic.vanilla.RealisticBiomeVanillaBase;
 import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
-
-import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Mod.Instance;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 
 
 //@Mod(modid = "RTG", name = "Realistic Terrain Generaton", version = "0.8.0d", dependencies = "required-after:Forge@[10.13.4.1448,)", acceptableRemoteVersions = "*")

--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -12,7 +12,6 @@ import rtg.config.ConfigManager;
 import rtg.event.EventManagerRTG;
 import rtg.event.WorldTypeMessageEventHandler;
 import rtg.reference.ModInfo;
-import rtg.util.Logger;
 import rtg.util.RealisticBiomePresenceTester;
 import rtg.world.WorldTypeRTG;
 import rtg.world.biome.realistic.abyssalcraft.RealisticBiomeACBase;
@@ -56,6 +55,9 @@ public class RTG {
     public static WorldTypeRTG worldtype;
     public static EventManagerRTG eventMgr;
 
+    private ArrayList<Runnable> oneShotServerCloseActions = new ArrayList<>();
+    private ArrayList<Runnable> serverCloseActions = new ArrayList<>();
+
     private ConfigManager configManager = new ConfigManager();
 
     public ConfigManager configManager(int dimension) {
@@ -64,22 +66,21 @@ public class RTG {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
-    {    
+    {
         instance = this;
         
         MapGenStructureIO.registerStructure(MapGenScatteredFeatureRTG.Start.class, "rtg_MapGenScatteredFeatureRTG");
         MapGenStructureIO.registerStructure(MapGenVillageRTG.Start.class, "rtg_MapGenVillageRTG");
 
-        Logger.info("[FMLPreInitializationEvent] Creating RTG's EventManager");
         eventMgr = new EventManagerRTG();
+        eventMgr.registerEventHandlers();
 
+        // This event handler unregisters itself, so it doesn't need to be a part of the event management system.
         MinecraftForge.EVENT_BUS.register(WorldTypeMessageEventHandler.instance);
 
+        // Biome configs MUST get initialised before the main config.
         MinecraftForge.EVENT_BUS.post(new BiomeConfigEvent.Pre());
-        
-        // This MUST get called before the config is initialised.
         BiomeConfigManager.initBiomeConfigs();
-        
         MinecraftForge.EVENT_BUS.post(new BiomeConfigEvent.Post());
         
         configPath = event.getModConfigurationDirectory() + "/RTG/";
@@ -87,13 +88,15 @@ public class RTG {
         
         worldtype = new WorldTypeRTG("RTG");
     }
-    
-//  @EventHandler public void init(FMLInitializationEvent event) {}
+
+    /*
+    @EventHandler
+    public void init(FMLInitializationEvent event) {}
+    */
 
     @EventHandler
     public void postInit(FMLPostInitializationEvent event)
     {
-
         RealisticBiomeVanillaBase.addBiomes();
         
         RealisticBiomeBOPBase.addBiomes();
@@ -118,8 +121,8 @@ public class RTG {
 
         RealisticBiomePresenceTester.doBiomeCheck();
     }
-    
-/*
+
+    /*
     @EventHandler
     public void serverAboutToStart(FMLServerAboutToStartEvent event) {}
     
@@ -131,8 +134,7 @@ public class RTG {
 
     @EventHandler
     public void serverStopping(FMLServerStoppingEvent event) {}
-*/
-
+    */
 
     public void runOnServerClose(Runnable action) {
         serverCloseActions.add(action);
@@ -142,8 +144,6 @@ public class RTG {
         serverCloseActions.add(action);
     }
 
-    private ArrayList<Runnable> oneShotServerCloseActions = new ArrayList<>();
-    private ArrayList<Runnable> serverCloseActions = new ArrayList<>();
     @EventHandler
     public void serverStopped(FMLServerStoppedEvent event)
     {
@@ -154,12 +154,5 @@ public class RTG {
             action.run();
         }
         oneShotServerCloseActions.clear();
-
-        if (eventMgr.isRegistered()) {
-            Logger.info("Unregistering RTG's Terrain Event Handlers...");
-            RTG.eventMgr.unRegisterEventHandlers();
-            if (!eventMgr.isRegistered()) Logger.info("RTG's Terrain Event Handlers have been unregistered successfully.");
-        }
-
     }
 }

--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -17,6 +17,10 @@ import net.minecraftforge.event.terraingen.WorldTypeEvent;
 import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
+import cpw.mods.fml.common.eventhandler.Event.Result;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
 import rtg.RTG;
 import rtg.config.rtg.ConfigRTG;
 import rtg.util.Acceptor;
@@ -32,9 +36,6 @@ import rtg.world.gen.genlayer.RiverRemover;
 import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
 
-import cpw.mods.fml.common.eventhandler.Event.Result;
-import cpw.mods.fml.common.eventhandler.EventPriority;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class EventManagerRTG
 {
@@ -119,6 +120,14 @@ public class EventManagerRTG
         public void initBiomeGensRTG(WorldTypeEvent.InitBiomeGens event) {
 
             if (!(event.worldType instanceof WorldTypeRTG)) {
+
+                /*
+                 * None of RTG's other event handlers need to be unregistered this early since they'll all
+                 * get unregistered before a non-RTG world loads when WorldEvent.Load is fired, but it's
+                 * better to be safe than sorry, so let's unregister them here to be safe.
+                 */
+                unRegisterEventHandlers();
+
                 return;
             }
 
@@ -350,8 +359,8 @@ public class EventManagerRTG
      * This method registers most of RTG's event handlers.
      *
      * We don't need to check if the event handlers are unregistered before registering them
-     * because Forge already performs those checks. This means that we could execute this method
-     * a million times, and it would stil only be registered once.
+     * because Forge already performs those checks. This means that we could execute this method a
+     * million times, and each event handler would still only be registered once.
      */
     public void registerEventHandlers() {
 


### PR DESCRIPTION
This should be working for all scenarios.

I've tested all combinations of loading and unloading RTG and non-RTG (superflat) worlds, and I didn't experience any crashes, chunk walls, or stone rivers.

But it's late, and this could do with more testing... but if everything checks out, we can release 1.1.1 ~~tomorrow night~~ later tonight.
