### PR TITLE
Structures fail gracefully when they fail.

### DIFF
--- a/etc/config/RTG/rtg.cfg
+++ b/etc/config/RTG/rtg.cfg
@@ -65,6 +65,12 @@ caves {
 
 
 debugging {
+    # Instead of crashing when it experiences 'java.util.ConcurrentModificationException' (or any other exception)
+    # during structure generation, RTG will stop trying to generate that structure and continue generating the world.
+    # You should only set this to TRUE if you have been instructed to do so by an RTG developer, or if you know what you're doing.
+    #  [default: false]
+    B:"Crash on Structure Exceptions"=false
+
     # WARNING: This should only be enabled if you know what you're doing.
     #  [default: false]
     B:"Enable Debugging"=false
@@ -454,11 +460,6 @@ villages {
     # Higher values = bigger villages; 0 = Vanilla
     #  [range: 0 ~ 10, default: 0]
     I:"Size of villages"=0
-
-    # Set this to TRUE to if you are experiencing 'java.util.ConcurrentModificationException' crashes related to village generation.
-    # Defaults to FALSE unless EnviroMine is installed, in which case it defaults to TRUE.
-    #  [default: false]
-    B:"Village Crash Fix"=false
 }
 
 

--- a/src/main/java/rtg/config/rtg/ConfigRTG.java
+++ b/src/main/java/rtg/config/rtg/ConfigRTG.java
@@ -54,6 +54,7 @@ public class ConfigRTG {
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     public static boolean enableDebugging = false;
+    public static boolean crashOnStructureExceptions = false;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Dunes
@@ -245,8 +246,6 @@ public class ConfigRTG {
     public static int minDistanceVillages = 12; // Vanilla = 8
     public static int maxDistanceVillages = 48; // Vanilla = 32
 
-    public static boolean villageCrashFix = (Loader.isModLoaded("enviromine"));
-
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Volcanoes
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -362,7 +361,25 @@ public class ConfigRTG {
             // Debugging
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-            enableDebugging = config.getBoolean("Enable Debugging", "Debugging", enableDebugging, "WARNING: This should only be enabled if you know what you're doing." + Configuration.NEW_LINE);
+            enableDebugging = config.getBoolean(
+                "Enable Debugging",
+                "Debugging",
+                enableDebugging,
+                "WARNING: This should only be enabled if you know what you're doing."
+                    + Configuration.NEW_LINE
+            );
+
+            crashOnStructureExceptions = config.getBoolean(
+                "Crash on Structure Exceptions",
+                "Debugging",
+                crashOnStructureExceptions,
+                "Instead of crashing when it experiences 'java.util.ConcurrentModificationException' (or any other exception)"
+                    + Configuration.NEW_LINE +
+                    "during structure generation, RTG will stop trying to generate that structure and continue generating the world."
+                    + Configuration.NEW_LINE +
+                    "You should only set this to TRUE if you have been instructed to do so by an RTG developer, or if you know what you're doing."
+                    + Configuration.NEW_LINE
+            );
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             // Dunes
@@ -830,16 +847,6 @@ public class ConfigRTG {
             villageSize = config.getInt("Size of villages", "Villages", villageSize, 0, 10, "Higher values = bigger villages; 0 = Vanilla" + Configuration.NEW_LINE);
             minDistanceVillages = config.getInt("Minimum distance between villages", "Villages", minDistanceVillages, 1, Integer.MAX_VALUE, "Higher values = villages further apart; 8 = Vanilla" + Configuration.NEW_LINE);
             maxDistanceVillages = config.getInt("Maximum distance between villages", "Villages", maxDistanceVillages, 1, Integer.MAX_VALUE, "Lower values = villages closer together; 32 = Vanilla" + Configuration.NEW_LINE);
-
-            villageCrashFix = config.getBoolean(
-                "Village Crash Fix",
-                "Villages",
-                villageCrashFix,
-                "Set this to TRUE to if you are experiencing 'java.util.ConcurrentModificationException' crashes related to village generation."
-                    + Configuration.NEW_LINE +
-                    "Defaults to FALSE unless EnviroMine is installed, in which case it defaults to TRUE."
-                    + Configuration.NEW_LINE
-            );
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             // Volcanoes

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -294,35 +294,73 @@ public class ChunkProviderRTG implements IChunkGenerator
         if (mapFeaturesEnabled) {
 
             if (ConfigRTG.generateMineshafts) {
-                mineshaftGenerator.generate(this.worldObj, cx, cy, primer);
+                try {
+                    mineshaftGenerator.generate(this.worldObj, cx, cy, primer);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateStrongholds) {
-                strongholdGenerator.generate(this.worldObj, cx, cy, primer);
+                try {
+                    strongholdGenerator.generate(this.worldObj, cx, cy, primer);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateVillages) {
-
-                if (ConfigRTG.villageCrashFix) {
-
-                    try {
-                        villageGenerator.generate(this.worldObj, cx, cy, primer);
-                    }
-                    catch (Exception e) {
-                        // Do nothing.
-                    }
-                }
-                else {
+                try {
                     villageGenerator.generate(this.worldObj, cx, cy, primer);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
                 }
             }
 
             if (ConfigRTG.generateScatteredFeatures) {
-                scatteredFeatureGenerator.generate(this.worldObj, cx, cy, primer);
+                try {
+                    scatteredFeatureGenerator.generate(this.worldObj, cx, cy, primer);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateOceanMonuments) {
-                oceanMonumentGenerator.generate(this.worldObj, cx, cy, primer);
+                try {
+                    oceanMonumentGenerator.generate(this.worldObj, cx, cy, primer);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
         }
 
@@ -684,44 +722,82 @@ public class ChunkProviderRTG implements IChunkGenerator
 
             TimeTracker.manager.start("Mineshafts");
             if (ConfigRTG.generateMineshafts) {
-                mineshaftGenerator.generateStructure(worldObj, rand, chunkCoords);
+                try {
+                    mineshaftGenerator.generateStructure(worldObj, rand, chunkCoords);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
             TimeTracker.manager.stop("Mineshafts");
 
             TimeTracker.manager.start("Strongholds");
             if (ConfigRTG.generateStrongholds) {
-                strongholdGenerator.generateStructure(worldObj, rand, chunkCoords);
+                try {
+                    strongholdGenerator.generateStructure(worldObj, rand, chunkCoords);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
             TimeTracker.manager.stop("Strongholds");
 
             TimeTracker.manager.start("Villages");
             if (ConfigRTG.generateVillages) {
-
-                if (ConfigRTG.villageCrashFix) {
-
-                    try {
-                        hasPlacedVillageBlocks = villageGenerator.generateStructure(worldObj, rand, chunkCoords);
-                    }
-                    catch (Exception e) {
-                        hasPlacedVillageBlocks = false;
-                    }
+                try {
+                    hasPlacedVillageBlocks = villageGenerator.generateStructure(worldObj, rand, chunkCoords);
                 }
-                else {
-
-                hasPlacedVillageBlocks = villageGenerator.generateStructure(worldObj, rand, chunkCoords);
+                catch (Exception e) {
+                    hasPlacedVillageBlocks = false;
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
                 }
             }
             TimeTracker.manager.stop("Villages");
 
             TimeTracker.manager.start("Scattered");
             if (ConfigRTG.generateScatteredFeatures) {
-                scatteredFeatureGenerator.generateStructure(worldObj, rand, chunkCoords);
+                try {
+                    scatteredFeatureGenerator.generateStructure(worldObj, rand, chunkCoords);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
             TimeTracker.manager.stop("Scattered");
 
             TimeTracker.manager.start("Monuments");
             if (ConfigRTG.generateOceanMonuments) {
-                oceanMonumentGenerator.generateStructure(this.worldObj, rand, chunkCoords);
+                try {
+                    oceanMonumentGenerator.generateStructure(this.worldObj, rand, chunkCoords);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
             TimeTracker.manager.stop("Monuments");
         }
@@ -1005,36 +1081,73 @@ public class ChunkProviderRTG implements IChunkGenerator
         if (mapFeaturesEnabled) {
 
             if (ConfigRTG.generateMineshafts) {
-                mineshaftGenerator.generate(worldObj, par1, par2, null);
+                try {
+                    mineshaftGenerator.generate(worldObj, par1, par2, null);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateStrongholds) {
-                strongholdGenerator.generate(worldObj, par1, par2, null);
+                try {
+                    strongholdGenerator.generate(worldObj, par1, par2, null);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateVillages) {
-
-                if (ConfigRTG.villageCrashFix) {
-
-                    try {
-                        villageGenerator.generate(this.worldObj, par1, par2, null);
-                    }
-                    catch (Exception e) {
-                        // Do nothing.
-                    }
-
-                }
-                else {
+                try {
                     villageGenerator.generate(this.worldObj, par1, par2, null);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
                 }
             }
 
             if (ConfigRTG.generateScatteredFeatures) {
-                scatteredFeatureGenerator.generate(this.worldObj, par1, par2, null);
+                try {
+                    scatteredFeatureGenerator.generate(this.worldObj, par1, par2, null);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
 
             if (ConfigRTG.generateOceanMonuments) {
-                oceanMonumentGenerator.generate(this.worldObj, par1, par2, null);
+                try {
+                    oceanMonumentGenerator.generate(this.worldObj, par1, par2, null);
+                }
+                catch (Exception e) {
+                    if (ConfigRTG.crashOnStructureExceptions) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                    else {
+                        Logger.fatal(e.getMessage(), e);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Even though this hasn't been an issue so far in 1.10.2, I've added this code here first as I plan to import the relevant changes from 1.10.2 to the other RTG versions after 1.10.2-4.1.1.2-snapshot-3 has been released.
