### PR TITLE
Better structure management.

### DIFF
--- a/etc/config/RTG/rtg.cfg
+++ b/etc/config/RTG/rtg.cfg
@@ -56,6 +56,7 @@ caves {
 
     # Must be set to TRUE for the other cave settings to have any effect.
     # If FALSE, RTG won't interfere with cave generation at all.
+    # WARNING! Setting this to FALSE may result in unpredictable cave generation.
     #  [default: true]
     B:"Enable Cave Modifications"=true
 
@@ -187,6 +188,7 @@ mineshafts {
 "ocean monuments" {
     # Must be set to TRUE for the other ocean monument settings to have any effect.
     # If FALSE, RTG won't interfere with ocean monument generation at all.
+    # WARNING! Setting this to FALSE may result in ocean monuments generating in unpredictable locations, including those outside of oceanic biomes.
     #  [default: true]
     B:"Enable Ocean Monument Modifications"=true
 
@@ -296,6 +298,7 @@ plateaus {
 ravines {
     # Must be set to TRUE for the other ravine settings to have any effect.
     # If FALSE, RTG won't interfere with ravine generation at all.
+    # WARNING! Setting this to FALSE may result in unpredictable ravine generation.
     #  [default: true]
     B:"Enable Ravine Modifications"=true
 
@@ -349,6 +352,7 @@ saplings {
 "scattered features" {
     # Must be set to TRUE for the other scattered feature settings to have any effect.
     # If FALSE, RTG won't interfere with scattered feature generation at all.
+    # WARNING! Setting this to FALSE may result in unpredictable scattered feature generation.
     #  [default: true]
     B:"Enable Scattered Feature Modifications"=true
 
@@ -375,6 +379,7 @@ snow {
 strongholds {
     # Must be set to TRUE for the other stronghold settings to have any effect.
     # If FALSE, RTG won't interfere with stronghold generation at all.
+    # WARNING! Setting this to FALSE may result in unpredictable stronghold generation.
     #  [default: true]
     B:"Enable Stronghold Modifications"=true
 
@@ -443,6 +448,7 @@ trees {
 villages {
     # Set this to FALSE to resolve issues with mods that also modify villages.
     # If set to FALSE, the 'Minimum distance between villages', 'Maximum distance between villages' & 'Size of villages' settings will have no effect.
+    # WARNING! Setting this to FALSE may result in unpredictable village generation.
     #  [default: true]
     B:"Enable village modifications"=true
 

--- a/src/main/java/rtg/config/rtg/ConfigRTG.java
+++ b/src/main/java/rtg/config/rtg/ConfigRTG.java
@@ -350,6 +350,8 @@ public class ConfigRTG {
                 "Must be set to TRUE for the other cave settings to have any effect."
                     + Configuration.NEW_LINE +
                     "If FALSE, RTG won't interfere with cave generation at all."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in unpredictable cave generation."
                     + Configuration.NEW_LINE
             );
 
@@ -501,6 +503,8 @@ public class ConfigRTG {
                 "Must be set to TRUE for the other ocean monument settings to have any effect."
                     + Configuration.NEW_LINE +
                     "If FALSE, RTG won't interfere with ocean monument generation at all."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in ocean monuments generating in unpredictable locations, including those outside of oceanic biomes."
                     + Configuration.NEW_LINE
             );
 
@@ -622,6 +626,8 @@ public class ConfigRTG {
                 "Must be set to TRUE for the other ravine settings to have any effect."
                     + Configuration.NEW_LINE +
                     "If FALSE, RTG won't interfere with ravine generation at all."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in unpredictable ravine generation."
                     + Configuration.NEW_LINE
             );
 
@@ -695,6 +701,8 @@ public class ConfigRTG {
                 "Must be set to TRUE for the other scattered feature settings to have any effect."
                     + Configuration.NEW_LINE +
                     "If FALSE, RTG won't interfere with scattered feature generation at all."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in unpredictable scattered feature generation."
                     + Configuration.NEW_LINE
             );
 
@@ -720,6 +728,8 @@ public class ConfigRTG {
                 "Must be set to TRUE for the other stronghold settings to have any effect."
                     + Configuration.NEW_LINE +
                     "If FALSE, RTG won't interfere with stronghold generation at all."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in unpredictable stronghold generation."
                     + Configuration.NEW_LINE
             );
 
@@ -840,6 +850,8 @@ public class ConfigRTG {
                 "Set this to FALSE to resolve issues with mods that also modify villages."
                     + Configuration.NEW_LINE +
                     "If set to FALSE, the 'Minimum distance between villages', 'Maximum distance between villages' & 'Size of villages' settings will have no effect."
+                    + Configuration.NEW_LINE +
+                    "WARNING! Setting this to FALSE may result in unpredictable village generation."
                     + Configuration.NEW_LINE
             );
 

--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -9,26 +9,25 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.biome.Biome;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.terraingen.*;
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
+import net.minecraftforge.event.terraingen.OreGenEvent;
+import net.minecraftforge.event.terraingen.SaplingGrowTreeEvent;
+import net.minecraftforge.event.terraingen.WorldTypeEvent;
 import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import rtg.config.rtg.ConfigRTG;
-import rtg.util.*;
+import rtg.util.Acceptor;
+import rtg.util.Logger;
+import rtg.util.RandomUtil;
+import rtg.util.SaplingUtil;
 import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
-import rtg.world.gen.MapGenCavesRTG;
-import rtg.world.gen.MapGenRavineRTG;
 import rtg.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.world.gen.genlayer.RiverRemover;
-import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
-import rtg.world.gen.structure.MapGenStrongholdRTG;
-import rtg.world.gen.structure.MapGenVillageRTG;
-import rtg.world.gen.structure.StructureOceanMonumentRTG;
 
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -39,13 +38,11 @@ public class EventManagerRTG {
     private final LoadChunkRTG LOAD_CHUNK_EVENT_HANDLER = new LoadChunkRTG();
     private final GenerateMinableRTG GENERATE_MINABLE_EVENT_HANDLER = new GenerateMinableRTG();
     private final InitBiomeGensRTG INIT_BIOME_GENS_EVENT_HANDLER = new InitBiomeGensRTG();
-    private final InitMapGenRTG INIT_MAP_GEN_EVENT_HANDLER = new InitMapGenRTG();
     private final SaplingGrowTreeRTG SAPLING_GROW_TREE_EVENT_HANDLER = new SaplingGrowTreeRTG();
     private final DecorateBiomeEventRTG DECORATE_BIOME_EVENT_HANDLER = new DecorateBiomeEventRTG();
 
     private WeakHashMap<Integer, Acceptor<ChunkEvent.Load>> chunkLoadEvents = new WeakHashMap<>();
     private long worldSeed;
-    private boolean isWorldTypeRTG = true;
 
     public EventManagerRTG() {
 
@@ -185,65 +182,6 @@ public class EventManagerRTG {
                 //throw ex;
                 // failed attempt because the GenLayers don't end with GenLayerRiverMix
             }
-        }
-    }
-
-    public class InitMapGenRTG {
-
-        @SubscribeEvent(priority = EventPriority.LOW)
-        public void initMapGenRTG(InitMapGenEvent event) {
-
-            // Are we in an RTG world?
-            if (!isWorldTypeRTG) {
-                return;
-            }
-
-            Logger.debug("event type = %s", event.getType().toString());
-            Logger.debug("event originalGen = %s", event.getOriginalGen().toString());
-
-            switch (event.getType()) {
-
-                case SCATTERED_FEATURE:
-                    if (ConfigRTG.enableScatteredFeatureModifications) {
-                        event.setNewGen(new MapGenScatteredFeatureRTG());
-                    }
-                    break;
-
-                case VILLAGE:
-                    if (ConfigRTG.enableVillageModifications) {
-                        event.setNewGen(new MapGenVillageRTG());
-                    }
-                    break;
-
-                case CAVE:
-                    if (ConfigRTG.enableCaveModifications) {
-                        event.setNewGen(new MapGenCavesRTG());
-                    }
-                    break;
-
-                case RAVINE:
-                    if (ConfigRTG.enableRavineModifications) {
-                        event.setNewGen(new MapGenRavineRTG());
-                    }
-                    break;
-
-                case OCEAN_MONUMENT:
-                    if (ConfigRTG.enableOceanMonumentModifications) {
-                        event.setNewGen(new StructureOceanMonumentRTG());
-                    }
-                    break;
-
-                case STRONGHOLD:
-                    if (ConfigRTG.enableStrongholdModifications) {
-                        event.setNewGen(new MapGenStrongholdRTG());
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-
-            Logger.debug("event newGen = %s", event.getNewGen().toString());
         }
     }
 
@@ -398,13 +336,6 @@ public class EventManagerRTG {
         }
 
         @SubscribeEvent
-        public void preBiomeDecorate(DecorateBiomeEvent.Pre event) {
-
-            //Are we in an RTG world?
-            isWorldTypeRTG = (event.getWorld().getWorldInfo().getTerrainType() instanceof WorldTypeRTG);
-        }
-
-        @SubscribeEvent
         public void onBiomeDecorate(DecorateBiomeEvent.Decorate event) {
 
             // Are flowing liquid modifications enabled?
@@ -449,7 +380,6 @@ public class EventManagerRTG {
         MinecraftForge.EVENT_BUS.register(LOAD_CHUNK_EVENT_HANDLER);
         MinecraftForge.ORE_GEN_BUS.register(GENERATE_MINABLE_EVENT_HANDLER);
         MinecraftForge.TERRAIN_GEN_BUS.register(INIT_BIOME_GENS_EVENT_HANDLER);
-        MinecraftForge.TERRAIN_GEN_BUS.register(INIT_MAP_GEN_EVENT_HANDLER);
         MinecraftForge.TERRAIN_GEN_BUS.register(SAPLING_GROW_TREE_EVENT_HANDLER);
         MinecraftForge.TERRAIN_GEN_BUS.register(DECORATE_BIOME_EVENT_HANDLER);
 

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -44,6 +44,10 @@ import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.biome.IBiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;
+import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
+import rtg.world.gen.structure.MapGenStrongholdRTG;
+import rtg.world.gen.structure.MapGenVillageRTG;
+import rtg.world.gen.structure.StructureOceanMonumentRTG;
 
 
 @SuppressWarnings({"UnusedParameters", "deprecation"})
@@ -118,27 +122,53 @@ public class ChunkProviderRTG implements IChunkGenerator
         m.put("size", "0");
         m.put("distance", "24");
         mapFeaturesEnabled = world.getWorldInfo().isMapFeaturesEnabled();
+
         boolean isRTGWorld = world.getWorldInfo().getTerrainType() instanceof WorldTypeRTG;
 
         if (isRTGWorld && ConfigRTG.enableCaveModifications) {
-            caveGenerator = TerrainGen.getModdedMapGen(new MapGenCavesRTG(), EventType.CAVE);
+            caveGenerator = (MapGenCaves) TerrainGen.getModdedMapGen(new MapGenCavesRTG(), EventType.CAVE);
         }
         else {
-            caveGenerator = TerrainGen.getModdedMapGen(new MapGenCaves(), EventType.CAVE);
+            caveGenerator = (MapGenCaves) TerrainGen.getModdedMapGen(new MapGenCaves(), EventType.CAVE);
         }
 
         if (isRTGWorld && ConfigRTG.enableRavineModifications) {
-            ravineGenerator = TerrainGen.getModdedMapGen(new MapGenRavineRTG(), EventType.RAVINE);
+            ravineGenerator = (MapGenRavine) TerrainGen.getModdedMapGen(new MapGenRavineRTG(), EventType.RAVINE);
         }
         else {
-            ravineGenerator = TerrainGen.getModdedMapGen(new MapGenRavine(), EventType.RAVINE);
+            ravineGenerator = (MapGenRavine) TerrainGen.getModdedMapGen(new MapGenRavine(), EventType.RAVINE);
         }
 
-        villageGenerator = (MapGenVillage) TerrainGen.getModdedMapGen(new MapGenVillage(m), EventType.VILLAGE);
-        strongholdGenerator = (MapGenStronghold) TerrainGen.getModdedMapGen(new MapGenStronghold(), EventType.STRONGHOLD);
+        if (isRTGWorld && ConfigRTG.enableVillageModifications) {
+            villageGenerator = (MapGenVillage) TerrainGen.getModdedMapGen(new MapGenVillageRTG(m), EventType.VILLAGE);
+        }
+        else {
+            villageGenerator = (MapGenVillage) TerrainGen.getModdedMapGen(new MapGenVillage(m), EventType.VILLAGE);
+        }
+
+        if (isRTGWorld && ConfigRTG.enableStrongholdModifications) {
+            strongholdGenerator = (MapGenStronghold) TerrainGen.getModdedMapGen(new MapGenStrongholdRTG(), EventType.STRONGHOLD);
+        }
+        else {
+            strongholdGenerator = (MapGenStronghold) TerrainGen.getModdedMapGen(new MapGenStronghold(), EventType.STRONGHOLD);
+        }
+
         mineshaftGenerator = (MapGenMineshaft) TerrainGen.getModdedMapGen(new MapGenMineshaft(), EventType.MINESHAFT);
-        scatteredFeatureGenerator = (MapGenScatteredFeature) TerrainGen.getModdedMapGen(new MapGenScatteredFeature(), EventType.SCATTERED_FEATURE);
-        oceanMonumentGenerator = (StructureOceanMonument) TerrainGen.getModdedMapGen(new StructureOceanMonument(), EventType.OCEAN_MONUMENT);
+
+        if (isRTGWorld && ConfigRTG.enableScatteredFeatureModifications) {
+            scatteredFeatureGenerator = (MapGenScatteredFeature) TerrainGen.getModdedMapGen(new MapGenScatteredFeatureRTG(), EventType.SCATTERED_FEATURE);
+        }
+        else {
+            scatteredFeatureGenerator = (MapGenScatteredFeature) TerrainGen.getModdedMapGen(new MapGenScatteredFeature(), EventType.SCATTERED_FEATURE);
+        }
+
+        if (isRTGWorld && ConfigRTG.enableOceanMonumentModifications) {
+            oceanMonumentGenerator = (StructureOceanMonument) TerrainGen.getModdedMapGen(new StructureOceanMonumentRTG(), EventType.OCEAN_MONUMENT);
+        }
+        else {
+            oceanMonumentGenerator = (StructureOceanMonument) TerrainGen.getModdedMapGen(new StructureOceanMonument(), EventType.OCEAN_MONUMENT);
+        }
+
         CanyonColour.init(l);
         sampleArraySize = sampleSize * 2 + 5;
         baseBiomesList = new Biome[256];


### PR DESCRIPTION
Ok, so... it turns out we don't even need InitMapGenRTG since we're using our own chunk provider, which means we can get rid of our preBiomeDecorate() event handler as well, which was only there so we could check to see if we're in an RTG world for the map gen event.

Since structures get assigned during chunk provision, and we already have access to the world at that stage, all we need to do is use our structure code if we're in an RTG world (and modifications have been enabled) and vanilla structure code if we're not. We're still posting to the TerrainGen.getModdedMapGen event, so other structure mods can still do their thing, but we're not listening to that event ourselves anymore, because we don't need to.

The only side effect of this is... if 'enableOceanMonumentModifications' is set to FALSE, then ocean monuments won't generate in RTG worlds because the vanilla ocean monument code doesn't work in RTG worlds. I haven't tested what happens if the other 'enabledXXXModifications' options are set to false, but all of the others _should_ work.

I'm submitting this PR for review now so that I can get some feedback whilst I'm testing the other modification options.
