### PR TITLE
Improve generic block crops world gen for determining maximum growth.

### DIFF
--- a/src/main/java/rtg/world/gen/feature/WorldGenCrops.java
+++ b/src/main/java/rtg/world/gen/feature/WorldGenCrops.java
@@ -60,22 +60,7 @@ public class WorldGenCrops extends WorldGenerator {
             }
         }
 
-        int maxGrowth;
-        PropertyInteger propertyValue;
-
-        if (farmType instanceof BlockPotato) {
-            propertyValue = BlockPotato.AGE;
-            maxGrowth = 8;
-        } else if (farmType instanceof BlockCarrot) {
-            propertyValue = BlockCarrot.AGE;
-            maxGrowth = 8;
-        } else if (farmType instanceof BlockBeetroot) {
-            propertyValue = BlockBeetroot.BEETROOT_AGE;
-            maxGrowth = 4;
-        } else {
-            propertyValue = BlockCrops.AGE;//Block Crops = Wheat
-            maxGrowth = 8;
-        }
+        int maxGrowth = ((BlockCrops) farmType).getMaxAge() + 1;
 
         int rx, ry, rz;
         for (int i = 0; i < farmDensity; i++) {
@@ -86,7 +71,7 @@ public class WorldGenCrops extends WorldGenerator {
 
             if ((b.getBlock() == Blocks.GRASS || b.getBlock() == Blocks.DIRT) && world.isAirBlock(new BlockPos(x + rx, y + ry + 1, z + rz))) {
                 world.setBlockState(new BlockPos(x + rx, y + ry, z + rz), Blocks.FARMLAND.getDefaultState().withProperty(BlockFarmland.MOISTURE,rand.nextInt(8)));
-                world.setBlockState(new BlockPos(x + rx, y +ry + 1, z + rz), farmType.getDefaultState().withProperty(propertyValue, rand.nextInt(maxGrowth)));
+                world.setBlockState(new BlockPos(x + rx, y +ry + 1, z + rz), ((BlockCrops) farmType).withAge(rand.nextInt(maxGrowth)));
             }
         }
 


### PR DESCRIPTION
This is a pretty straightforward cleaner way to retrieve the maximum growth for `WorldGenCrops` and determine the max growth `IBlockState`. I've tested it locally and it works in vanilla environments (Which is what I understand this to be targeting in the first place).

Let me know if this should be changed at all or anything.
