### PR TITLE
DecoTree now posts custom TREE event.

### DIFF
--- a/src/main/java/rtg/event/terraingen/DecorateBiomeEventRTG.java
+++ b/src/main/java/rtg/event/terraingen/DecorateBiomeEventRTG.java
@@ -1,0 +1,53 @@
+package rtg.event.terraingen;
+
+import java.util.Random;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
+
+
+public class DecorateBiomeEventRTG extends DecorateBiomeEvent
+{
+    public DecorateBiomeEventRTG(World world, Random rand, BlockPos pos)
+    {
+        super(world, rand, pos);
+    }
+
+    /**
+     * This event is fired when a chunk is decorated with a biome feature.
+     *
+     * You can set the result to DENY to prevent the default biome decoration.
+     */
+    @HasResult
+    public static class DecorateRTG extends DecorateBiomeEvent.Decorate
+    {
+        private final Decorate.EventType type;
+        private int amount = -1;
+
+        public DecorateRTG(World world, Random rand, BlockPos pos, Decorate.EventType type, int amount)
+        {
+            super(world, rand, pos, type);
+            this.type = type;
+            this.amount = amount;
+        }
+
+        public DecorateRTG(World world, Random rand, BlockPos pos, Decorate.EventType type)
+        {
+            this(world, rand, pos, type, -1);
+        }
+
+        public boolean hasAmountData() {
+            return this.amount != -1;
+        }
+
+        public int getModifiedAmount() {
+            return this.amount;
+        }
+
+        public void setModifiedAmount(int amount) {
+            this.amount = amount;
+        }
+    }
+}


### PR DESCRIPTION
Since RTG posts a TREE event for each batch of trees it tries to generate (instead of one event per chunk), DecoTree now posts this custom event so that we can pass the number of trees RTG expects to generate in each batch.

This provides more contextual information to mods like Recurrent Complex, which can use the info to better determine how to handle each batch of trees.

Because the custom event extends `DecorateBiomeEvent.Decorate`, it still works with mods that don't need the additional context.
