### PR TITLE
RTG trees no longer replace blocks they shouldn't.

### DIFF
--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTG.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTG.java
@@ -164,4 +164,11 @@ public class TreeRTG extends WorldGenAbstractTree {
 
         return true;
     }
+
+    protected void setTreeBlock(World world, BlockPos pos, IBlockState block, int generateFlag) {
+
+        if (this.isReplaceable(world, pos)) {
+            world.setBlockState(pos, block, generateFlag);
+        }
+    }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTG.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTG.java
@@ -165,10 +165,17 @@ public class TreeRTG extends WorldGenAbstractTree {
         return true;
     }
 
-    protected void setTreeBlock(World world, BlockPos pos, IBlockState block, int generateFlag) {
+    protected void placeLogBlock(World world, BlockPos pos, IBlockState logBlock, int generateFlag) {
 
         if (this.isReplaceable(world, pos)) {
-            world.setBlockState(pos, block, generateFlag);
+            world.setBlockState(pos, logBlock, generateFlag);
+        }
+    }
+
+    protected void placeLeavesBlock(World world, BlockPos pos, IBlockState leavesBlock, int generateFlag) {
+
+        if (world.isAirBlock(pos)) {
+            world.setBlockState(pos, leavesBlock, generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaAbyssinica.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaAbyssinica.java
@@ -58,7 +58,7 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
         int bh = h - 6;
 
         for (int i = 0; i < h; i++) {
-            world.setBlockState(new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         genLeaves(world, rand, x, y + h, z);
 
@@ -74,7 +74,7 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
             c = 1;
 
             while (sh < h) {
-                world.setBlockState(new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
                 sh++;
                 c += 0.5f;
             }
@@ -92,21 +92,21 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
             int j;
             for (i = -2; i <= 2; i++) {
                 for (j = -2; j <= 2; j++) {
-                    if (world.isAirBlock(new BlockPos(x + i, y + 1, z + j)) && Math.abs(i) + Math.abs(j) < 4) {
-                        world.setBlockState(new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
+                    if (Math.abs(i) + Math.abs(j) < 4) {
+                        this.setTreeBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
 
             for (i = -3; i <= 3; i++) {
                 for (j = -3; j <= 3; j++) {
-                    if (world.isAirBlock(new BlockPos(x + i, y, z + j)) && Math.abs(i) + Math.abs(j) < 5) {
-                        world.setBlockState(new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
+                    if (Math.abs(i) + Math.abs(j) < 5) {
+                        this.setTreeBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
         }
 
-        world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaAbyssinica.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaAbyssinica.java
@@ -58,7 +58,7 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
         int bh = h - 6;
 
         for (int i = 0; i < h; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         genLeaves(world, rand, x, y + h, z);
 
@@ -74,7 +74,7 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
             c = 1;
 
             while (sh < h) {
-                this.setTreeBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
                 sh++;
                 c += 0.5f;
             }
@@ -93,7 +93,7 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
             for (i = -2; i <= 2; i++) {
                 for (j = -2; j <= 2; j++) {
                     if (Math.abs(i) + Math.abs(j) < 4) {
-                        this.setTreeBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
+                        this.placeLeavesBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
@@ -101,12 +101,12 @@ public class TreeRTGAcaciaAbyssinica extends TreeRTG {
             for (i = -3; i <= 3; i++) {
                 for (j = -3; j <= 3; j++) {
                     if (Math.abs(i) + Math.abs(j) < 5) {
-                        this.setTreeBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
+                        this.placeLeavesBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
         }
 
-        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaBucheri.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaBucheri.java
@@ -58,7 +58,7 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
         int bh = h - 3;
 
         for (int i = 0; i < h; i++) {
-            world.setBlockState(new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         genLeaves(world, rand, x, y + h, z);
 
@@ -74,7 +74,7 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
             c = 1;
 
             while (sh < h) {
-                world.setBlockState(new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
                 sh++;
                 c += 0.5f;
             }
@@ -92,21 +92,19 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
             int j;
             for (i = -1; i <= 1; i++) {
                 for (j = -1; j <= 1; j++) {
-                    if (world.isAirBlock(new BlockPos(x + i, y + 1, z + j))) {
-                        world.setBlockState(new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
-                    }
+                    this.setTreeBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
                 }
             }
 
             for (i = -2; i <= 2; i++) {
                 for (j = -2; j <= 2; j++) {
-                    if (world.isAirBlock(new BlockPos(x + i, y, z + j)) && Math.abs(i) + Math.abs(j) < 4) {
-                        world.setBlockState(new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
+                    if (Math.abs(i) + Math.abs(j) < 4) {
+                        this.setTreeBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
         }
 
-        world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaBucheri.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGAcaciaBucheri.java
@@ -58,7 +58,7 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
         int bh = h - 3;
 
         for (int i = 0; i < h; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         genLeaves(world, rand, x, y + h, z);
 
@@ -74,7 +74,7 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
             c = 1;
 
             while (sh < h) {
-                this.setTreeBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + (int) (xd * c), y + sh, z + (int) (yd * c)), this.logBlock, this.generateFlag);
                 sh++;
                 c += 0.5f;
             }
@@ -92,19 +92,19 @@ public class TreeRTGAcaciaBucheri extends TreeRTG {
             int j;
             for (i = -1; i <= 1; i++) {
                 for (j = -1; j <= 1; j++) {
-                    this.setTreeBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x + i, y + 1, z + j), this.leavesBlock, this.generateFlag);
                 }
             }
 
             for (i = -2; i <= 2; i++) {
                 for (j = -2; j <= 2; j++) {
                     if (Math.abs(i) + Math.abs(j) < 4) {
-                        this.setTreeBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
+                        this.placeLeavesBlock(world, new BlockPos(x + i, y, z + j), this.leavesBlock, this.generateFlag);
                     }
                 }
             }
         }
 
-        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGBetulaPapyrifera.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGBetulaPapyrifera.java
@@ -2,8 +2,6 @@ package rtg.world.gen.feature.tree.rtg;
 
 import java.util.Random;
 
-import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -59,7 +57,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
         int i;
         for (i = 0; i < this.trunkSize; i++) {
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -87,7 +85,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
                 buildBranch(world, rand, x, y, z, dX, dZ, 1, i < this.crownSize - 2 ? 2 : 1); //i < treeSize - 4 ? 2 : 1
             }
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < this.crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -129,7 +127,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            world.setBlockState(new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -137,10 +135,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            if (b.getMaterial() == Material.AIR) {
-                world.setBlockState(new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
-            }
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGBetulaPapyrifera.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGBetulaPapyrifera.java
@@ -57,7 +57,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
         int i;
         for (i = 0; i < this.trunkSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -85,7 +85,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
                 buildBranch(world, rand, x, y, z, dX, dZ, 1, i < this.crownSize - 2 ? 2 : 1); //i < treeSize - 4 ? 2 : 1
             }
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < this.crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -127,7 +127,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -135,7 +135,7 @@ public class TreeRTGBetulaPapyrifera extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaPentandra.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaPentandra.java
@@ -113,7 +113,7 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize; i < y + this.crownSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -158,10 +158,10 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
             }
             else {
-                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -182,12 +182,12 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 0.6f) {
-                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
+                            this.placeLogBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
 
-                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaPentandra.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaPentandra.java
@@ -113,7 +113,7 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize; i < y + this.crownSize; i++) {
-            world.setBlockState(new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -158,10 +158,10 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                world.setBlockState(new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
             }
             else {
-                world.setBlockState(new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -182,14 +182,12 @@ public class TreeRTGCeibaPentandra extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 0.6f) {
-                            world.setBlockState(new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
 
-                            if (world.isAirBlock(new BlockPos(x + i, y + j, z + k))) {
-                                world.setBlockState(new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
-                            }
+                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaRosea.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaRosea.java
@@ -115,8 +115,8 @@ public class TreeRTGCeibaRosea extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize - 2; i < y + this.crownSize + 2; i++) {
-            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x + 1, i, z + 1), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + 1, i, z + 1), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -167,10 +167,10 @@ public class TreeRTGCeibaRosea extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
             }
             else {
-                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -191,12 +191,12 @@ public class TreeRTGCeibaRosea extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 1.3f) {
-                            this.setTreeBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.logBlock, this.generateFlag);
+                            this.placeLogBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
 
-                            this.setTreeBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaRosea.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCeibaRosea.java
@@ -115,8 +115,8 @@ public class TreeRTGCeibaRosea extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize - 2; i < y + this.crownSize + 2; i++) {
-            world.setBlockState(new BlockPos(x, i, z), this.logBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x + 1, i, z + 1), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + 1, i, z + 1), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -167,10 +167,10 @@ public class TreeRTGCeibaRosea extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                world.setBlockState(new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.trunkLog, this.generateFlag);
             }
             else {
-                world.setBlockState(new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int) x, (int) y, (int) z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -191,14 +191,12 @@ public class TreeRTGCeibaRosea extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 1.3f) {
-                            world.setBlockState(new BlockPos((int) x + i, (int) y + j, (int) z + k), this.logBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
 
-                            if (world.isAirBlock(new BlockPos((int) x + i, (int) y + j, (int) z + k))) {
-                                world.setBlockState(new BlockPos((int) x + i, (int) y + j, (int) z + k), this.leavesBlock, this.generateFlag);
-                            }
+                            this.setTreeBlock(world, new BlockPos((int) x + i, (int) y + j, (int) z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCocosNucifera.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCocosNucifera.java
@@ -150,7 +150,7 @@ public class TreeRTGCocosNucifera extends TreeRTG {
 
         while (c < length) {
 
-            world.setBlockState(new BlockPos((int) posX, (int) posY, (int) posZ), this.trunkLog, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos((int) posX, (int) posY, (int) posZ), this.trunkLog, this.generateFlag);
 
             if (c < length - 3) {
                 loss = Math.abs(velX) + Math.abs(velZ);
@@ -173,14 +173,14 @@ public class TreeRTGCocosNucifera extends TreeRTG {
         if (!this.noLeaves) {
 
             for (int j = 0; j < leavesLength; j += 3) {
-                world.setBlockState(new BlockPos(x + leaves[j], y + leaves[j + 1], z + leaves[j + 2]), this.leavesBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + leaves[j], y + leaves[j + 1], z + leaves[j + 2]), this.leavesBlock, this.generateFlag);
             }
         }
 
         for (int k = 0; k < cocoasLength; k += 4) {
             if (rand.nextInt(20) == 0) {
                 //TODO: cocoas[k + 0] + 8 (meta)
-                world.setBlockState(new BlockPos(x + cocoas[k + 1], y + cocoas[k + 2], z + cocoas[k + 3]), Blocks.COCOA.getDefaultState(), this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + cocoas[k + 1], y + cocoas[k + 2], z + cocoas[k + 3]), Blocks.COCOA.getDefaultState(), this.generateFlag);
             }
         }
 

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCocosNucifera.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCocosNucifera.java
@@ -150,7 +150,7 @@ public class TreeRTGCocosNucifera extends TreeRTG {
 
         while (c < length) {
 
-            this.setTreeBlock(world, new BlockPos((int) posX, (int) posY, (int) posZ), this.trunkLog, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos((int) posX, (int) posY, (int) posZ), this.trunkLog, this.generateFlag);
 
             if (c < length - 3) {
                 loss = Math.abs(velX) + Math.abs(velZ);
@@ -173,14 +173,14 @@ public class TreeRTGCocosNucifera extends TreeRTG {
         if (!this.noLeaves) {
 
             for (int j = 0; j < leavesLength; j += 3) {
-                this.setTreeBlock(world, new BlockPos(x + leaves[j], y + leaves[j + 1], z + leaves[j + 2]), this.leavesBlock, this.generateFlag);
+                this.placeLeavesBlock(world, new BlockPos(x + leaves[j], y + leaves[j + 1], z + leaves[j + 2]), this.leavesBlock, this.generateFlag);
             }
         }
 
         for (int k = 0; k < cocoasLength; k += 4) {
             if (rand.nextInt(20) == 0) {
                 //TODO: cocoas[k + 0] + 8 (meta)
-                this.setTreeBlock(world, new BlockPos(x + cocoas[k + 1], y + cocoas[k + 2], z + cocoas[k + 3]), Blocks.COCOA.getDefaultState(), this.generateFlag);
+                world.setBlockState(new BlockPos(x + cocoas[k + 1], y + cocoas[k + 2], z + cocoas[k + 3]), Blocks.COCOA.getDefaultState(), this.generateFlag);
             }
         }
 

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCupressusSempervirens.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCupressusSempervirens.java
@@ -52,7 +52,7 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
 
         int i, j, k;
         for (i = 0; i < this.trunkSize; i++) {
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -65,12 +65,12 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
                 for (j = -2; j <= 2; j++) {
                     for (k = -2; k <= 2; k++) {
                         if (Math.abs(j) + Math.abs(k) != 4 && ((j > -2 && k > -2 && j < 2 && k < 2) || rand.nextInt(4) != 0)) {
-                            world.setBlockState(new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
             }
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -80,37 +80,37 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
                 for (j = -1; j <= 1; j++) {
                     for (k = -1; k <= 1; k++) {
                         if (Math.abs(j) + Math.abs(k) < 2 || (rand.nextInt(4) != 0)) {
-                            world.setBlockState(new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
 
                 if (i == 0) {
-                    world.setBlockState(new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
                 }
             }
 
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
-        world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
         if (!this.noLeaves) {
-            world.setBlockState(new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
 
-            world.setBlockState(new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
         }
 
         return true;

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCupressusSempervirens.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGCupressusSempervirens.java
@@ -52,7 +52,7 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
 
         int i, j, k;
         for (i = 0; i < this.trunkSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -65,12 +65,12 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
                 for (j = -2; j <= 2; j++) {
                     for (k = -2; k <= 2; k++) {
                         if (Math.abs(j) + Math.abs(k) != 4 && ((j > -2 && k > -2 && j < 2 && k < 2) || rand.nextInt(4) != 0)) {
-                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
             }
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -80,37 +80,36 @@ public class TreeRTGCupressusSempervirens extends TreeRTG {
                 for (j = -1; j <= 1; j++) {
                     for (k = -1; k <= 1; k++) {
                         if (Math.abs(j) + Math.abs(k) < 2 || (rand.nextInt(4) != 0)) {
-                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
 
                 if (i == 0) {
-                    this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
                 }
             }
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
-        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
         if (!this.noLeaves) {
-            this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-
-            this.setTreeBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
         }
 
         return true;

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaPungens.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaPungens.java
@@ -55,7 +55,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
 
         int i, j, k;
         for (i = 0; i < this.trunkSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -65,12 +65,12 @@ public class TreeRTGPiceaPungens extends TreeRTG {
                 for (j = -2; j <= 2; j++) {
                     for (k = -2; k <= 2; k++) {
                         if (Math.abs(j) + Math.abs(k) != 4 && ((j > -2 && k > -2 && j < 2 && k < 2) || rand.nextInt(4) != 0)) {
-                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
             }
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -80,38 +80,37 @@ public class TreeRTGPiceaPungens extends TreeRTG {
                 for (j = -1; j <= 1; j++) {
                     for (k = -1; k <= 1; k++) {
                         if (Math.abs(j) + Math.abs(k) < 2 || (rand.nextInt(4) != 0)) {
-                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
 
                 if (i == 0) {
-                    this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
-                    this.setTreeBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
+                    this.placeLeavesBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
                 }
             }
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
-        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
         if (!this.noLeaves) {
 
-            this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-
-            this.setTreeBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
-            this.setTreeBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
         }
 
         return true;
@@ -131,7 +130,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -140,7 +139,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaPungens.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaPungens.java
@@ -2,8 +2,6 @@ package rtg.world.gen.feature.tree.rtg;
 
 import java.util.Random;
 
-import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -57,7 +55,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
 
         int i, j, k;
         for (i = 0; i < this.trunkSize; i++) {
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -67,12 +65,12 @@ public class TreeRTGPiceaPungens extends TreeRTG {
                 for (j = -2; j <= 2; j++) {
                     for (k = -2; k <= 2; k++) {
                         if (Math.abs(j) + Math.abs(k) != 4 && ((j > -2 && k > -2 && j < 2 && k < 2) || rand.nextInt(4) != 0)) {
-                            world.setBlockState(new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
             }
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -82,38 +80,38 @@ public class TreeRTGPiceaPungens extends TreeRTG {
                 for (j = -1; j <= 1; j++) {
                     for (k = -1; k <= 1; k++) {
                         if (Math.abs(j) + Math.abs(k) < 2 || (rand.nextInt(4) != 0)) {
-                            world.setBlockState(new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + j, y, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }
 
                 if (i == 0) {
-                    world.setBlockState(new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
-                    world.setBlockState(new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x + 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x - 2, y, z), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z + 2), this.leavesBlock, this.generateFlag);
+                    this.setTreeBlock(world, new BlockPos(x, y, z - 2), this.leavesBlock, this.generateFlag);
                 }
             }
 
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
-        world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+        this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
         if (!this.noLeaves) {
 
-            world.setBlockState(new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + 1, y, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x - 1, y, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z + 1), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z - 1), this.leavesBlock, this.generateFlag);
 
-            world.setBlockState(new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
-            world.setBlockState(new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + 1, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + 2, z), this.leavesBlock, this.generateFlag);
         }
 
         return true;
@@ -133,7 +131,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            world.setBlockState(new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -142,10 +140,7 @@ public class TreeRTGPiceaPungens extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            if (b.getMaterial() == Material.AIR) {
-                world.setBlockState(new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
-            }
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaSitchensis.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaSitchensis.java
@@ -2,8 +2,6 @@ package rtg.world.gen.feature.tree.rtg;
 
 import java.util.Random;
 
-import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -62,7 +60,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
         int i;
         for (i = 0; i < this.trunkSize; i++) {
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -90,7 +88,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
                 buildBranch(world, rand, x, y, z, dX, dZ, i < this.crownSize - 10 ? 2 : 1, i < this.crownSize - 6 ? 2 : 1);
             }
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < this.crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -133,7 +131,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            world.setBlockState(new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -142,10 +140,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            if (b.getMaterial() == Material.AIR) {
-                world.setBlockState(new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
-            }
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaSitchensis.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPiceaSitchensis.java
@@ -60,7 +60,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
         int i;
         for (i = 0; i < this.trunkSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             y++;
         }
 
@@ -88,7 +88,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
                 buildBranch(world, rand, x, y, z, dX, dZ, i < this.crownSize - 10 ? 2 : 1, i < this.crownSize - 6 ? 2 : 1);
             }
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < this.crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -131,7 +131,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -140,7 +140,7 @@ public class TreeRTGPiceaSitchensis extends TreeRTG {
 
         if (!this.noLeaves) {
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusMonticola.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusMonticola.java
@@ -132,7 +132,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                                 if ((Math.abs(i3) != l3 || Math.abs(k3) != l3 || l3 <= 0)
                                     && world.getBlockState(pos5).getBlock().canBeReplacedByLeaves(world.getBlockState(pos5), world, pos5)) {
                                     if (!this.noLeaves) {
-                                        this.setTreeBlock(world, new BlockPos(l2, k2, j3), this.leavesBlock, this.generateFlag);
+                                        this.placeLeavesBlock(world, new BlockPos(l2, k2, j3), this.leavesBlock, this.generateFlag);
                                     }
                                 }
                             }
@@ -155,7 +155,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                     i4 = rand.nextInt(3);
 
                     for (k2 = 0; k2 < l - i4; ++k2) {
-                        this.setTreeBlock(world, new BlockPos(x, y + k2, z), this.logBlock, this.generateFlag);
+                        this.placeLogBlock(world, new BlockPos(x, y + k2, z), this.logBlock, this.generateFlag);
                     }
 
                     if (this.height > 4) {
@@ -187,7 +187,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                     break;
                 }
 
-                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }
@@ -211,7 +211,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -221,7 +221,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
         if (!this.noLeaves) {
 
             IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusMonticola.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusMonticola.java
@@ -4,7 +4,6 @@ import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLog;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
@@ -95,13 +94,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                     for (int j2 = z - l3; j2 <= z + l3 && flag; ++j2) {
                         if (l1 >= 0 && l1 < 256) {
                             BlockPos pos2 = new BlockPos(new BlockPos(i2, l1, j2));
-                            IBlockState block = world.getBlockState(pos2);
-
-                            if (!block.getBlock().isAir(block, world, pos2)
-                                && !block.getBlock().isLeaves(block, world, pos2)
-                                && block != Blocks.SNOW_LAYER.getDefaultState()) {
-                                flag = false;
-                            }
+                            flag = this.isReplaceable(world, pos2);
                         }
                         else {
                             flag = false;
@@ -139,7 +132,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                                 if ((Math.abs(i3) != l3 || Math.abs(k3) != l3 || l3 <= 0)
                                     && world.getBlockState(pos5).getBlock().canBeReplacedByLeaves(world.getBlockState(pos5), world, pos5)) {
                                     if (!this.noLeaves) {
-                                        world.setBlockState(new BlockPos(l2, k2, j3), this.leavesBlock, this.generateFlag);
+                                        this.setTreeBlock(world, new BlockPos(l2, k2, j3), this.leavesBlock, this.generateFlag);
                                     }
                                 }
                             }
@@ -162,14 +155,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                     i4 = rand.nextInt(3);
 
                     for (k2 = 0; k2 < l - i4; ++k2) {
-                        IBlockState block2 = world.getBlockState(new BlockPos(x, y + k2, z));
-                        BlockPos pos4 = new BlockPos(x, y + k2, z);
-
-                        if (block2.getBlock().isAir(block2, world, pos4)
-                            || block2.getBlock().isLeaves(block2, world, pos4)
-                            || block2 == Blocks.SNOW_LAYER.getDefaultState()) {
-                            world.setBlockState(new BlockPos(x, y + k2, z), this.logBlock, this.generateFlag);
-                        }
+                        this.setTreeBlock(world, new BlockPos(x, y + k2, z), this.logBlock, this.generateFlag);
                     }
 
                     if (this.height > 4) {
@@ -201,7 +187,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
                     break;
                 }
 
-                world.setBlockState(new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }
@@ -225,7 +211,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            world.setBlockState(new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -235,9 +221,7 @@ public class TreeRTGPinusMonticola extends TreeRTG {
         if (!this.noLeaves) {
 
             IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            if (b.getMaterial() == Material.AIR) {
-                world.setBlockState(new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
-            }
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusNigra.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusNigra.java
@@ -67,7 +67,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
         float branchIncrease = 0.25f;
 
         for (int i = 0; i <= height; i++) {
-            world.setBlockState(new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         buildLeaves(world, rand, x, y + height, z, 2);
         buildTrunk(world, rand, x, y, z);
@@ -82,7 +82,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
             yd = (float) Math.sin(dir * Math.PI / 180f);
 
             for (b = 0; b <= bl; b++) {
-                world.setBlockState(new BlockPos(x + (int) (b * xd), y + j, z + (int) (b * yd)), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + (int) (b * xd), y + j, z + (int) (b * yd)), this.trunkLog, this.generateFlag);
             }
             buildLeaves(world, rand, x, y + j, z, 2);
             buildLeaves(world, rand, x + (int) (b * xd), y + j, z + (int) (b * yd), 2);
@@ -103,8 +103,8 @@ public class TreeRTGPinusNigra extends TreeRTG {
                     for (int k = -size; k <= size; k++) {
                         l = i * i + j * j + k * k;
                         if (l <= t) {
-                            if (world.isAirBlock(new BlockPos(x + i, y + j, z + k)) && (l < t / 2 || rand.nextBoolean())) {
-                                world.setBlockState(new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                            if ((l < t / 2 || rand.nextBoolean())) {
+                                this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                             }
                         }
                     }
@@ -125,7 +125,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
                     break;
                 }
 
-                world.setBlockState(new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusNigra.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusNigra.java
@@ -67,7 +67,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
         float branchIncrease = 0.25f;
 
         for (int i = 0; i <= height; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         buildLeaves(world, rand, x, y + height, z, 2);
         buildTrunk(world, rand, x, y, z);
@@ -82,7 +82,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
             yd = (float) Math.sin(dir * Math.PI / 180f);
 
             for (b = 0; b <= bl; b++) {
-                this.setTreeBlock(world, new BlockPos(x + (int) (b * xd), y + j, z + (int) (b * yd)), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + (int) (b * xd), y + j, z + (int) (b * yd)), this.trunkLog, this.generateFlag);
             }
             buildLeaves(world, rand, x, y + j, z, 2);
             buildLeaves(world, rand, x + (int) (b * xd), y + j, z + (int) (b * yd), 2);
@@ -104,7 +104,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
                         l = i * i + j * j + k * k;
                         if (l <= t) {
                             if ((l < t / 2 || rand.nextBoolean())) {
-                                this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                                this.placeLeavesBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                             }
                         }
                     }
@@ -125,7 +125,7 @@ public class TreeRTGPinusNigra extends TreeRTG {
                     break;
                 }
 
-                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusPonderosa.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusPonderosa.java
@@ -75,7 +75,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
 
         int i;
         for (i = 0; i < trunkSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             if (i > 5 && rand.nextInt(7) == 0) {
                 int dX = -1 + rand.nextInt(3);
                 int dZ = -1 + rand.nextInt(3);
@@ -120,7 +120,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
                 );
             }
 
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -155,7 +155,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
         int h = (int) Math.ceil(this.trunkSize / 4f);
         h = h + rand.nextInt(h * 2);
         for (int i = -1; i < h; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.trunkLog, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y + i, z), this.trunkLog, this.generateFlag);
         }
     }
 
@@ -177,7 +177,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -185,7 +185,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
     public void buildLeaves(World world, int x, int y, int z) {
 
         if (!this.noLeaves) {
-            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusPonderosa.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGPinusPonderosa.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Random;
 
 import net.minecraft.block.BlockLog;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -76,7 +75,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
 
         int i;
         for (i = 0; i < trunkSize; i++) {
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
             if (i > 5 && rand.nextInt(7) == 0) {
                 int dX = -1 + rand.nextInt(3);
                 int dZ = -1 + rand.nextInt(3);
@@ -120,7 +119,8 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
                     i < crownSize - 5 ? 2 : 1
                 );
             }
-            world.setBlockState(new BlockPos(x, y, z), this.logBlock, this.generateFlag);
+
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.logBlock, this.generateFlag);
 
             if (i < crownSize - 2) {
                 if (rand.nextBoolean()) {
@@ -155,7 +155,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
         int h = (int) Math.ceil(this.trunkSize / 4f);
         h = h + rand.nextInt(h * 2);
         for (int i = -1; i < h; i++) {
-            world.setBlockState(new BlockPos(x, y + i, z), this.trunkLog, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.trunkLog, this.generateFlag);
         }
     }
 
@@ -177,7 +177,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
         }
 
         for (int m = 1; m <= logLength; m++) {
-            world.setBlockState(new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x + (dX * m), y, z + (dZ * m)), this.logBlock, this.generateFlag);
         }
     }
 
@@ -185,11 +185,7 @@ public class TreeRTGPinusPonderosa extends TreeRTG {
     public void buildLeaves(World world, int x, int y, int z) {
 
         if (!this.noLeaves) {
-
-            IBlockState b = world.getBlockState(new BlockPos(x, y, z));
-            if (b.getMaterial() == Material.AIR) {
-                world.setBlockState(new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
-            }
+            this.setTreeBlock(world, new BlockPos(x, y, z), this.leavesBlock, this.generateFlag);
         }
     }
 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGRhizophoraMucronata.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGRhizophoraMucronata.java
@@ -94,7 +94,7 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize; i < y + this.crownSize; i++) {
-            world.setBlockState(new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -139,10 +139,10 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                world.setBlockState(new BlockPos((int)x, (int)y, (int)z), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int)x, (int)y, (int)z), this.trunkLog, this.generateFlag);
             }
             else {
-                world.setBlockState(new BlockPos((int)x, (int)y, (int)z), this.logBlock, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos((int)x, (int)y, (int)z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -163,14 +163,11 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 0.6f) {
-                            world.setBlockState(new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
+                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
-
-                            if (world.isAirBlock(new BlockPos(x + i, y + j, z + k))) {
-                                world.setBlockState(new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
-                            }
+                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGRhizophoraMucronata.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGRhizophoraMucronata.java
@@ -94,7 +94,7 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
         }
 
         for (int i = y + this.trunkSize; i < y + this.crownSize; i++) {
-            this.setTreeBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, i, z), this.logBlock, this.generateFlag);
         }
 
         float horDir, verDir;
@@ -139,10 +139,10 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
         while (c < length) {
 
             if (isTrunk) {
-                this.setTreeBlock(world, new BlockPos((int)x, (int)y, (int)z), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int)x, (int)y, (int)z), this.trunkLog, this.generateFlag);
             }
             else {
-                this.setTreeBlock(world, new BlockPos((int)x, (int)y, (int)z), this.logBlock, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos((int)x, (int)y, (int)z), this.logBlock, this.generateFlag);
             }
 
             x += velX;
@@ -163,11 +163,11 @@ public class TreeRTGRhizophoraMucronata extends TreeRTG {
                     dist = Math.abs((float) i / width) + (float) Math.abs(j) + Math.abs((float) k / width);
                     if (dist <= size - 0.5f || (dist <= size && rand.nextBoolean())) {
                         if (dist < 0.6f) {
-                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
+                            this.placeLogBlock(world, new BlockPos(x + i, y + j, z + k), this.logBlock, this.generateFlag);
                         }
 
                         if (!this.noLeaves) {
-                            this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                            this.placeLeavesBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                         }
                     }
                 }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGSalixMyrtilloides.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGSalixMyrtilloides.java
@@ -69,7 +69,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
         int branchLenght = 6;
 
         for (int i = 0; i < height; i++) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.placeLogBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         createLeavesAroundBranch(world, rand, x, y + height, z, 3, 2);
         createTrunk(world, rand, x, y, z);
@@ -94,7 +94,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
                 c++;
                 hd += 0.5f;
 
-                this.setTreeBlock(world, 
+                this.placeLogBlock(world,
                     new BlockPos(x + (int) (c * xd), y + (int) hd, z + (int) (c * yd)), this.trunkLog, this.generateFlag
                 );
             }
@@ -116,7 +116,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
                         if ((l < t - c || rand.nextBoolean())) {
                             if (!this.noLeaves) {
 
-                                this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                                this.placeLeavesBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                                 if (j < -(s - 2) && rand.nextInt(3) != 0) {
                                     createVine(world, rand, x + i, y + j, z + k);
                                 }
@@ -132,7 +132,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
 
         int r = rand.nextInt(3) + 5;
         for (int i = -1; i > -r; i--) {
-            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.leavesBlock, this.generateFlag);
+            this.placeLeavesBlock(world, new BlockPos(x, y + i, z), this.leavesBlock, this.generateFlag);
         }
     }
 
@@ -144,7 +144,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
         for (int t = 0; t < 5; t++) {
             sh = rand.nextInt(3) + y;
             while (sh > y - 3) {
-                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.placeLogBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }

--- a/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGSalixMyrtilloides.java
+++ b/src/main/java/rtg/world/gen/feature/tree/rtg/TreeRTGSalixMyrtilloides.java
@@ -69,7 +69,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
         int branchLenght = 6;
 
         for (int i = 0; i < height; i++) {
-            world.setBlockState(new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.logBlock, this.generateFlag);
         }
         createLeavesAroundBranch(world, rand, x, y + height, z, 3, 2);
         createTrunk(world, rand, x, y, z);
@@ -94,7 +94,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
                 c++;
                 hd += 0.5f;
 
-                world.setBlockState(
+                this.setTreeBlock(world, 
                     new BlockPos(x + (int) (c * xd), y + (int) hd, z + (int) (c * yd)), this.trunkLog, this.generateFlag
                 );
             }
@@ -113,10 +113,10 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
                 for (int k = -s; k <= s; k++) {
                     l = i * i + j * j + k * k;
                     if (l <= t) {
-                        if (world.isAirBlock(new BlockPos(x + i, y + j, z + k)) && (l < t - c || rand.nextBoolean())) {
+                        if ((l < t - c || rand.nextBoolean())) {
                             if (!this.noLeaves) {
 
-                                world.setBlockState(new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
+                                this.setTreeBlock(world, new BlockPos(x + i, y + j, z + k), this.leavesBlock, this.generateFlag);
                                 if (j < -(s - 2) && rand.nextInt(3) != 0) {
                                     createVine(world, rand, x + i, y + j, z + k);
                                 }
@@ -132,10 +132,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
 
         int r = rand.nextInt(3) + 5;
         for (int i = -1; i > -r; i--) {
-            if (!world.isAirBlock(new BlockPos(x, y + i, z))) {
-                break;
-            }
-            world.setBlockState(new BlockPos(x, y + i, z), this.leavesBlock, this.generateFlag);
+            this.setTreeBlock(world, new BlockPos(x, y + i, z), this.leavesBlock, this.generateFlag);
         }
     }
 
@@ -147,7 +144,7 @@ public class TreeRTGSalixMyrtilloides extends TreeRTG {
         for (int t = 0; t < 5; t++) {
             sh = rand.nextInt(3) + y;
             while (sh > y - 3) {
-                world.setBlockState(new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
+                this.setTreeBlock(world, new BlockPos(x + pos[t * 2], sh, z + pos[t * 2 + 1]), this.trunkLog, this.generateFlag);
                 sh--;
             }
         }


### PR DESCRIPTION
Before an RTG tree places a block, it now checks WordGenAbstractTree#isReplaceable to see if it's allowed to do so.

As part of this PR, I've also gone through and removed all other instances of 'replaceable block checking' because it's all redundant now that we're using isReplaceable().

I'm still in the process of testing this, but I thought I'd post it for review now in case anyone spots something wrong.
