### PR TITLE
Once-per-chunk ore generation.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -3,7 +3,7 @@
 mod_id=RTG
 mod_name=Realistic Terrain Generation
 mod_desc=Adds a new world type which generates realistic terrain for Overworld biomes.
-mod_version=4.1.2.1
+mod_version=4.1.2.2
 mc_version=1.10.2
 mod_url=https://github.com/Team-RTG/Realistic-Terrain-Generation
 mod_author="Team RTG"

--- a/mod_deps.properties
+++ b/mod_deps.properties
@@ -1,15 +1,16 @@
 # mod_deps should be 'after:<mod identifier>' (unquoted, semicolon-separated, \escaped for newline, see example below)
 # TODO: DEPRECATED remove CookingPlus in 1.11, mod ID is now 'agriculturalrevolution'
-bopver=1.10.2-5.0.0.2085
+bopver=1.10.2-5.0.0.2068
 acver=1.10.2-1.9.2.9
-depstring=after:BiomesOPlenty@[5.0.0.2085,);\
-            after:AbyssalCraftAPI@[1.8.1,);\
+depstring=after:AbyssalCraftAPI@[1.8.1,);\
+            after:agriculturalrevolution@[0.9.0,);\
             after:arsmagica2@[1.5.012,);\
             after:betteragriculture@[0.16,);\
+            after:BiomesOPlenty@[5.0.0.2068,);\
             after:BiomesYouGo@[4.0.0,);\
             after:CookingPlus@[0.8.7,);\
-            after:agriculturalrevolution@[0.9.0,);\
             after:flowercraft@[6.01,);\
             after:morechinesemc@[1.2.1,);\
+            after:mw@[0.7.1,);\
             after:reccomplex@[1.2.3,);\
             after:sugiforest@[1.2.2,)

--- a/src/main/java/rtg/api/util/ChunkOreGenTracker.java
+++ b/src/main/java/rtg/api/util/ChunkOreGenTracker.java
@@ -1,0 +1,29 @@
+package rtg.api.util;
+
+import java.util.HashSet;
+
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * Created by WhichOnesPink on 04/01/2017.
+ */
+public class ChunkOreGenTracker {
+
+    private HashSet<BlockPos> oreChunks = new HashSet<>();
+
+    public ChunkOreGenTracker() {
+
+    }
+
+    public synchronized void addOreChunk(BlockPos pos) {
+        oreChunks.add(pos);
+    }
+
+    public synchronized void removeOreChunk(BlockPos pos) {
+        oreChunks.remove(pos);
+    }
+
+    public synchronized boolean hasGeneratedOres(BlockPos pos) {
+        return this.oreChunks.contains(pos);
+    }
+}

--- a/src/main/java/rtg/api/util/TimedHashMap.java
+++ b/src/main/java/rtg/api/util/TimedHashMap.java
@@ -79,7 +79,7 @@ public class TimedHashMap<Key,Value> implements Map<Key,Value> {
     }
 
     private synchronized void clearEntries() {
-        link.clear();;
+        link.clear();
     }
 
     abstract class LinkEntry {

--- a/src/main/java/rtg/api/util/TimedHashSet.java
+++ b/src/main/java/rtg/api/util/TimedHashSet.java
@@ -74,7 +74,7 @@ public class TimedHashSet<Type> implements Set<Type> {
     }
 
     private synchronized void clearEntries() {
-        link.clear();;
+        link.clear();
     }
 
     private abstract class LinkEntry {

--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -6,6 +6,8 @@ import java.util.WeakHashMap;
 import net.minecraft.block.BlockSapling;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
 import net.minecraftforge.common.MinecraftForge;
@@ -24,12 +26,14 @@ import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.Ev
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
 import rtg.api.util.Acceptor;
+import rtg.api.util.ChunkOreGenTracker;
 import rtg.api.util.RandomUtil;
 import rtg.util.Logger;
 import rtg.util.SaplingUtil;
 import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
+import rtg.world.gen.ChunkProviderRTG;
 import rtg.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.world.gen.genlayer.RiverRemover;
 
@@ -65,7 +69,7 @@ public class EventManagerRTG {
         public void loadChunkRTG(ChunkEvent.Load event) {
 
             // Are we in an RTG world?
-            if (!(event.getWorld().getWorldInfo().getTerrainType() instanceof WorldTypeRTG)) {
+            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG)) {
                 return;
             }
 
@@ -81,96 +85,101 @@ public class EventManagerRTG {
         @SubscribeEvent
         public void generateMinableRTG(OreGenEvent.GenerateMinable event) {
 
+            World world = event.getWorld();
+
             // Are we in an RTG world?
-            if (!(event.getWorld().getWorldInfo().getTerrainType() instanceof WorldTypeRTG)) {
+            if (!(world.getWorldType() instanceof WorldTypeRTG)) {
                 return;
             }
 
-            String eventName = null;
+            ChunkProviderRTG cprtg = WorldTypeRTG.chunkProvider;
+            ChunkOreGenTracker chunkOreGenTracker = cprtg.getChunkOreGenTracker();
+            BlockPos eventPos = event.getPos();
             OreGenEvent.GenerateMinable.EventType eventType = event.getType();
+            String eventName = null;
 
             // No switch statements allowed! - Pink
 
             if (eventType == ANDESITE) {
                 eventName = "ANDESITE";
-                if (!rtgConfig.GENERATE_ORE_ANDESITE.get()) {
+                if (!rtgConfig.GENERATE_ORE_ANDESITE.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == COAL) {
                 eventName = "COAL";
-                if (!rtgConfig.GENERATE_ORE_COAL.get()) {
+                if (!rtgConfig.GENERATE_ORE_COAL.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == DIAMOND) {
                 eventName = "DIAMOND";
-                if (!rtgConfig.GENERATE_ORE_DIAMOND.get()) {
+                if (!rtgConfig.GENERATE_ORE_DIAMOND.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == DIORITE) {
                 eventName = "DIORITE";
-                if (!rtgConfig.GENERATE_ORE_DIORITE.get()) {
+                if (!rtgConfig.GENERATE_ORE_DIORITE.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == DIRT) {
                 eventName = "DIRT";
-                if (!rtgConfig.GENERATE_ORE_DIRT.get()) {
+                if (!rtgConfig.GENERATE_ORE_DIRT.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == EMERALD) {
                 eventName = "EMERALD";
-                if (!rtgConfig.GENERATE_ORE_EMERALD.get()) {
+                if (!rtgConfig.GENERATE_ORE_EMERALD.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == GOLD) {
                 eventName = "GOLD";
-                if (!rtgConfig.GENERATE_ORE_GOLD.get()) {
+                if (!rtgConfig.GENERATE_ORE_GOLD.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == GRANITE) {
                 eventName = "GRANITE";
-                if (!rtgConfig.GENERATE_ORE_GRANITE.get()) {
+                if (!rtgConfig.GENERATE_ORE_GRANITE.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == GRAVEL) {
                 eventName = "GRAVEL";
-                if (!rtgConfig.GENERATE_ORE_GRAVEL.get()) {
+                if (!rtgConfig.GENERATE_ORE_GRAVEL.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == IRON) {
                 eventName = "IRON";
-                if (!rtgConfig.GENERATE_ORE_IRON.get()) {
+                if (!rtgConfig.GENERATE_ORE_IRON.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == LAPIS) {
                 eventName = "LAPIS";
-                if (!rtgConfig.GENERATE_ORE_LAPIS.get()) {
+                if (!rtgConfig.GENERATE_ORE_LAPIS.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == REDSTONE) {
                 eventName = "REDSTONE";
-                if (!rtgConfig.GENERATE_ORE_REDSTONE.get()) {
+                if (!rtgConfig.GENERATE_ORE_REDSTONE.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
             else if (eventType == SILVERFISH) {
                 eventName = "SILVERFISH";
-                if (!rtgConfig.GENERATE_ORE_SILVERFISH.get()) {
+                if (!rtgConfig.GENERATE_ORE_SILVERFISH.get() || chunkOreGenTracker.hasGeneratedOres(eventPos)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
 
-            //Logger.debug("%s EVENT @ %d %d %d (%d %d)", eventName, event.getPos().getX(), event.getPos().getY(), event.getPos().getZ(), (event.getPos().getX() / 16), (event.getPos().getZ() / 16));
+            //Logger.debug("%s EVENT @ %d %d %d (%d %d)", eventName, eventPos.getX(), eventPos.getY(), eventPos.getZ(), (eventPos.getX() / 16), (eventPos.getZ() / 16));
         }
     }
 
@@ -210,7 +219,7 @@ public class EventManagerRTG {
             }
 
             // Are we in an RTG world? Do we have RTG's chunk manager?
-            if (!(event.getWorld().getWorldInfo().getTerrainType() instanceof WorldTypeRTG) ||
+            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG) ||
                 !(event.getWorld().getBiomeProvider() instanceof BiomeProviderRTG)) {
                 return;
             }
@@ -375,7 +384,7 @@ public class EventManagerRTG {
             }
 
             // Are we in an RTG world? Do we have RTG's chunk manager?
-            if (!(event.getWorld().getWorldInfo().getTerrainType() instanceof WorldTypeRTG) ||
+            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG) ||
                 !(event.getWorld().getBiomeProvider() instanceof BiomeProviderRTG)) {
                 return;
             }

--- a/src/main/java/rtg/world/biome/BiomeDecoratorRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeDecoratorRTG.java
@@ -42,9 +42,11 @@ public class BiomeDecoratorRTG
     }
 
     /*
-     * This method should only be called by DecoBaseBiomeDecorations or rDecorateSeedBiome().
+     * This method should only be called by ChunkProviderRTG#generateOres.
      */
-    public void decorateOres(World worldIn, Random random, int worldX, int worldZ, OpenSimplexNoise simplex, CellNoise cell, float border, float river, boolean hasPlacedVillageBlocks) {
+    public void decorateOres(World worldIn, Random random, int worldX, int worldZ) {
+
+        //Logger.debug("Started generating ores in %s (%d %d)", this.biome.getBiomeName(), worldX, worldZ);
 
         BiomeDecorator biomeDecorator = biome.theBiomeDecorator;
 
@@ -116,6 +118,8 @@ public class BiomeDecoratorRTG
             this.genStandardOre1(worldIn, random, rbb.getExtraGoldGenCount(), biomeDecorator.goldGen, rbb.getExtraGoldGenMinHeight(), rbb.getExtraGoldGenMaxHeight());
         }
         MinecraftForge.ORE_GEN_BUS.post(new OreGenEvent.Post(worldIn, random, pos));
+
+        //Logger.debug("Finished generating ores in %s (%d %d)", this.biome.getBiomeName(), worldX, worldZ);
     }
 
     public void genStandardOre1(World worldIn, Random random, int blockCount, WorldGenerator generator, int minHeight, int maxHeight)
@@ -208,15 +212,11 @@ public class BiomeDecoratorRTG
     /**
      * When manually decorating biomes, sometimes you want the biome to partially decorate itself.
      * That's what this method does... it calls the biome's decorate() method.
-     * If the conditions for decoration aren't met, we still need to generate ores.
      */
     public void rDecorateSeedBiome(World world, Random rand, int worldX, int worldZ, OpenSimplexNoise simplex, CellNoise cell, float strength, float river) {
 
         if (strength > 0.3f) {
             this.biome.decorate(world, rand, new BlockPos(worldX, 0, worldZ));
-        }
-        else {
-            this.decorateOres(world, rand, worldX, worldZ, simplex, cell, strength, river, false);
         }
     }
 

--- a/src/main/java/rtg/world/biome/deco/DecoBaseBiomeDecorations.java
+++ b/src/main/java/rtg/world/biome/deco/DecoBaseBiomeDecorations.java
@@ -8,11 +8,6 @@ import rtg.api.world.RTGWorld;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 
 /**
- * This deco replaces the cumbersome rDecorateSeedBiome & rOreGenSeedBiome logic.
- * Instead of having to remember when to use (and not use) rDecorateSeedBiome/rOreGenSeedBiome,
- * now all you have to do is add this configured deco to the realistic biome wherever you want the base biome
- * to decorate itself. You no longer need to worry about ore gen because that gets handled automatically.
- *
  * @author WhichOnesPink
  */
 public class DecoBaseBiomeDecorations extends DecoBase {
@@ -60,50 +55,32 @@ public class DecoBaseBiomeDecorations extends DecoBase {
     @Override
     public void generate(RealisticBiomeBase biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
-        // The X and Z coords need to be randomized here to prevent massive ore veins.
-        int intX = worldX + rand.nextInt(16);// + 8;
-        int intZ = worldZ + rand.nextInt(16);// + 8;
-
         if (this.allowed) {
 
             for (int i = 0; i < loops; i++) {
 
-                intX = worldX + rand.nextInt(16);// + 8;
-                intZ = worldZ + rand.nextInt(16);// + 8;
-                int intY = rtgWorld.world.getHeight(new BlockPos(intX, 0, intZ)).getY();
+                int intY = rtgWorld.world.getHeight(new BlockPos(worldX, 0, worldZ)).getY();
 
                 if (intY >= this.minY && intY <= this.maxY) {
 
                     if (this.equalsZeroChance > 0) {
 
                         if (rand.nextInt(this.equalsZeroChance) == 0) {
-                            biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
-                        }
-                        else {
-                            biome.rDecorator.decorateOres(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river, hasPlacedVillageBlocks);
+                            biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
                         }
                     }
                     else if (this.notEqualsZeroChance > 0) {
 
                         if (rand.nextInt(this.notEqualsZeroChance) != 0) {
-                            biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
-                        }
-                        else {
-                            biome.rDecorator.decorateOres(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river, hasPlacedVillageBlocks);
+                            biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
                         }
                     }
                     else {
 
-                        biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
+                        biome.rDecorator.rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
                     }
                 }
-                else {
-                    biome.rDecorator.decorateOres(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river, hasPlacedVillageBlocks);
-                }
             }
-        }
-        else {
-            biome.rDecorator.decorateOres(rtgWorld.world, rand, intX, intZ, rtgWorld.simplex, rtgWorld.cell, strength, river, hasPlacedVillageBlocks);
         }
     }
 

--- a/src/main/java/rtg/world/biome/deco/collection/DecoCollectionBirchForest.java
+++ b/src/main/java/rtg/world/biome/deco/collection/DecoCollectionBirchForest.java
@@ -1,0 +1,100 @@
+package rtg.world.biome.deco.collection;
+
+import net.minecraft.world.gen.feature.WorldGenTrees;
+
+import rtg.api.util.BlockUtil;
+import rtg.world.biome.deco.*;
+import rtg.world.biome.deco.helper.DecoHelperRandomSplit;
+import rtg.world.gen.feature.tree.rtg.TreeRTG;
+import rtg.world.gen.feature.tree.rtg.TreeRTGBetulaPapyrifera;
+import static rtg.world.biome.deco.DecoFallenTree.LogCondition.RANDOM_CHANCE;
+
+
+/**
+ * @author WhichOnesPink
+ */
+public class DecoCollectionBirchForest extends DecoCollectionBase {
+
+    private DecoTree.Distribution forestDistribution = new DecoTree.Distribution(80f, 60f, -15f);
+
+    public DecoCollectionBirchForest(boolean fallenTrees) {
+
+        this
+            .addDeco(tallBirchTrees())
+            .addDeco(randomTrees())
+            .addDeco(logs(), fallenTrees) // Add some fallen birch trees.
+            .addDeco(shrubsOak()) // Oak shrubs to fill in the blanks.
+            .addDeco(baseBiomeDecorations()) // Let the biome partially-decorate itself.
+            .addDeco(flowers()) // Only 1-block tall flowers so we can see the trees better.
+            .addDeco(grass()) // Grass filler.
+        ;
+    }
+
+    private DecoHelperRandomSplit randomTrees() {
+        return new DecoHelperRandomSplit()
+            .setDecos(new DecoBase[]{tallBirchTrees(), vanillaTrees()})
+            .setChances(new int[]{10, 4});
+    }
+
+    private DecoTree tallBirchTrees() {
+
+        TreeRTG birchTree = new TreeRTGBetulaPapyrifera()
+            .setLogBlock(BlockUtil.getStateLog(2))
+            .setLeavesBlock(BlockUtil.getStateLeaf(2))
+            .setMinTrunkSize(4)
+            .setMaxTrunkSize(10)
+            .setMinCrownSize(8)
+            .setMaxCrownSize(19);
+
+        this.addTree(birchTree);
+
+        return new DecoTree(birchTree)
+            .setStrengthFactorForLoops(3f)
+            .setTreeType(DecoTree.TreeType.RTG_TREE)
+            .setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE)
+            .setMaxY(100);
+    }
+
+    private DecoTree vanillaTrees() {
+        return new DecoTree(new WorldGenTrees(false))
+            .setTreeType(DecoTree.TreeType.WORLDGEN)
+            .setStrengthFactorForLoops(3f)
+            .setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE)
+            .setMaxY(100);
+    }
+
+    private DecoFallenTree logs() {
+        return new DecoFallenTree()
+            .setLogCondition(RANDOM_CHANCE)
+            .setLogConditionChance(8)
+            .setLogBlock(BlockUtil.getStateLog(2))
+            .setLeavesBlock(BlockUtil.getStateLeaf(2))
+            .setMinSize(3)
+            .setMaxSize(6);
+    }
+
+    private DecoShrub shrubsOak() {
+        return new DecoShrub()
+            .setMaxY(120)
+            .setStrengthFactor(3f);
+    }
+
+    private DecoBaseBiomeDecorations baseBiomeDecorations() {
+        return new DecoBaseBiomeDecorations()
+            .setNotEqualsZeroChance(3);
+    }
+
+    private DecoFlowersRTG flowers() {
+        return new DecoFlowersRTG()
+            .setFlowers(new int[]{3, 6})
+            .setMaxY(128)
+            .setStrengthFactor(12f);
+    }
+
+    private DecoGrass grass() {
+        return new DecoGrass()
+            .setMinY(60)
+            .setMaxY(128)
+            .setStrengthFactor(20f);
+    }
+}

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOasis.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOasis.java
@@ -166,7 +166,7 @@ public class RealisticBiomeBOPOasis extends RealisticBiomeBOPBase {
         decoFallenTree.getDistribution().setNoiseAddend(-15f);
         decoFallenTree.setLogCondition(RANDOM_CHANCE);
         decoFallenTree.setLogConditionChance(16);
-        decoFallenTree.setLogBlock(BOPBlocks.log_2.getStateFromMeta(3));
+        decoFallenTree.setLogBlock(BOPBlocks.log_1.getStateFromMeta(7));
         decoFallenTree.setLeavesBlock(Blocks.LEAVES.getDefaultState());
         decoFallenTree.setMinSize(3);
         decoFallenTree.setMaxSize(5);

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalIsland.java
@@ -167,7 +167,7 @@ public class RealisticBiomeBOPTropicalIsland extends RealisticBiomeBOPBase {
         decoFallenTree.setLogCondition(RANDOM_CHANCE);
         decoFallenTree.setLogConditionNoise(0f);
         decoFallenTree.setLogConditionChance(12);
-        decoFallenTree.setLogBlock(BOPBlocks.log_2.getStateFromMeta(3));
+        decoFallenTree.setLogBlock(BOPBlocks.log_1.getStateFromMeta(7));
         decoFallenTree.setLeavesBlock(Blocks.LEAVES.getDefaultState());
         decoFallenTree.setMinSize(3);
         decoFallenTree.setMaxSize(4);

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
@@ -8,21 +8,16 @@ import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.feature.WorldGenTrees;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.world.RTGWorld;
-import rtg.world.biome.deco.*;
-import rtg.world.biome.deco.helper.DecoHelperRandomSplit;
-import rtg.world.gen.feature.tree.rtg.TreeRTG;
-import rtg.world.gen.feature.tree.rtg.TreeRTGBetulaPapyrifera;
+import rtg.world.biome.deco.collection.DecoCollectionBirchForest;
 import rtg.world.gen.surface.SurfaceBase;
 import rtg.world.gen.terrain.GroundEffect;
 import rtg.world.gen.terrain.TerrainBase;
-import static rtg.world.biome.deco.DecoFallenTree.LogCondition.RANDOM_CHANCE;
 
 public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase {
 
@@ -173,79 +168,6 @@ public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase 
 
     @Override
     public void initDecos() {
-
-        TreeRTG birchSmall = new TreeRTGBetulaPapyrifera();
-        birchSmall.setLogBlock(BlockUtil.getStateLog(2));
-        birchSmall.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchSmall.setMinTrunkSize(4);
-        birchSmall.setMaxTrunkSize(10);
-        birchSmall.setMinCrownSize(8);
-        birchSmall.setMaxCrownSize(19);
-        this.addTree(birchSmall);
-
-        DecoTree smallBirch = new DecoTree(birchSmall);
-        smallBirch.setStrengthNoiseFactorForLoops(true);
-        smallBirch.setTreeType(DecoTree.TreeType.RTG_TREE);
-        smallBirch.getDistribution().setNoiseDivisor(80f);
-        smallBirch.getDistribution().setNoiseFactor(60f);
-        smallBirch.getDistribution().setNoiseAddend(-15f);
-        smallBirch.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        smallBirch.setMaxY(120);
-        this.addDeco(smallBirch);
-
-        TreeRTG birchTree = new TreeRTGBetulaPapyrifera();
-        birchTree.setLogBlock(BlockUtil.getStateLog(2));
-        birchTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchTree.setMinTrunkSize(4);
-        birchTree.setMaxTrunkSize(10);
-        birchTree.setMinCrownSize(8);
-        birchTree.setMaxCrownSize(19);
-        this.addTree(birchTree);
-
-        DecoTree birchTrees = new DecoTree(birchTree);
-        birchTrees.setStrengthFactorForLoops(3f);
-        birchTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
-        birchTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        birchTrees.setMaxY(100);
-
-        DecoTree rtgTrees = new DecoTree(new WorldGenTrees(false));
-        rtgTrees.setTreeType(DecoTree.TreeType.WORLDGEN);
-        rtgTrees.setStrengthFactorForLoops(3f);
-        rtgTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        rtgTrees.setMaxY(100);
-
-        DecoHelperRandomSplit decoHelperRandomSplit = new DecoHelperRandomSplit();
-        decoHelperRandomSplit.decos = new DecoBase[]{birchTrees, rtgTrees};
-        decoHelperRandomSplit.chances = new int[]{10, 4};
-        this.addDeco(decoHelperRandomSplit);
-
-        DecoFallenTree decoFallenTree = new DecoFallenTree();
-        decoFallenTree.setLogCondition(RANDOM_CHANCE);
-        decoFallenTree.setLogConditionChance(8);
-        decoFallenTree.setLogBlock(BlockUtil.getStateLog(2));
-        decoFallenTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        decoFallenTree.setMinSize(3);
-        decoFallenTree.setMaxSize(6);
-        this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
-
-        DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(120);
-        decoShrub.setStrengthFactor(3f);
-        this.addDeco(decoShrub);
-
-        DecoBaseBiomeDecorations decoBaseBiomeDecorations = new DecoBaseBiomeDecorations();
-        decoBaseBiomeDecorations.setNotEqualsZeroChance(3);
-        this.addDeco(decoBaseBiomeDecorations);
-
-        DecoFlowersRTG decoFlowersRTG = new DecoFlowersRTG();
-        decoFlowersRTG.setFlowers(new int[]{3, 6});
-        decoFlowersRTG.setMaxY(128);
-        decoFlowersRTG.setStrengthFactor(12f);
-        this.addDeco(decoFlowersRTG);
-
-        DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
-        decoGrass.setStrengthFactor(20f);
-        this.addDeco(decoGrass);
+        this.addDecoCollection(new DecoCollectionBirchForest(this.getConfig().ALLOW_LOGS.get()));
     }
 }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
@@ -8,20 +8,15 @@ import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.feature.WorldGenTrees;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.world.RTGWorld;
-import rtg.world.biome.deco.*;
-import rtg.world.biome.deco.helper.DecoHelperRandomSplit;
-import rtg.world.gen.feature.tree.rtg.TreeRTG;
-import rtg.world.gen.feature.tree.rtg.TreeRTGBetulaPapyrifera;
+import rtg.world.biome.deco.collection.DecoCollectionBirchForest;
 import rtg.world.gen.surface.SurfaceBase;
 import rtg.world.gen.terrain.TerrainBase;
-import static rtg.world.biome.deco.DecoFallenTree.LogCondition.RANDOM_CHANCE;
 
 public class RealisticBiomeVanillaBirchForestHills extends RealisticBiomeVanillaBase {
 
@@ -179,79 +174,6 @@ public class RealisticBiomeVanillaBirchForestHills extends RealisticBiomeVanilla
 
     @Override
     public void initDecos() {
-
-        TreeRTG birchSmall = new TreeRTGBetulaPapyrifera();
-        birchSmall.setLogBlock(BlockUtil.getStateLog(2));
-        birchSmall.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchSmall.setMinTrunkSize(4);
-        birchSmall.setMaxTrunkSize(10);
-        birchSmall.setMinCrownSize(8);
-        birchSmall.setMaxCrownSize(19);
-        this.addTree(birchSmall);
-
-        DecoTree smallBirch = new DecoTree(birchSmall);
-        smallBirch.setStrengthNoiseFactorForLoops(true);
-        smallBirch.setTreeType(DecoTree.TreeType.RTG_TREE);
-        smallBirch.getDistribution().setNoiseDivisor(80f);
-        smallBirch.getDistribution().setNoiseFactor(60f);
-        smallBirch.getDistribution().setNoiseAddend(-15f);
-        smallBirch.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        smallBirch.setMaxY(120);
-        this.addDeco(smallBirch);
-
-        TreeRTG birchTree = new TreeRTGBetulaPapyrifera();
-        birchTree.setLogBlock(BlockUtil.getStateLog(2));
-        birchTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchTree.setMinTrunkSize(4);
-        birchTree.setMaxTrunkSize(10);
-        birchTree.setMinCrownSize(8);
-        birchTree.setMaxCrownSize(19);
-        this.addTree(birchTree);
-
-        DecoTree birchTrees = new DecoTree(birchTree);
-        birchTrees.setStrengthFactorForLoops(3f);
-        birchTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
-        birchTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        birchTrees.setMaxY(100);
-
-        DecoTree rtgTrees = new DecoTree(new WorldGenTrees(false));
-        rtgTrees.setTreeType(DecoTree.TreeType.WORLDGEN);
-        rtgTrees.setStrengthFactorForLoops(3f);
-        rtgTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        rtgTrees.setMaxY(100);
-
-        DecoHelperRandomSplit decoHelperRandomSplit = new DecoHelperRandomSplit();
-        decoHelperRandomSplit.decos = new DecoBase[]{birchTrees, rtgTrees};
-        decoHelperRandomSplit.chances = new int[]{10, 4};
-        this.addDeco(decoHelperRandomSplit);
-
-        DecoFallenTree decoFallenTree = new DecoFallenTree();
-        decoFallenTree.setLogCondition(RANDOM_CHANCE);
-        decoFallenTree.setLogConditionChance(8);
-        decoFallenTree.setLogBlock(BlockUtil.getStateLog(2));
-        decoFallenTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        decoFallenTree.setMinSize(3);
-        decoFallenTree.setMaxSize(6);
-        this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
-
-        DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(120);
-        decoShrub.setStrengthFactor(3f);
-        this.addDeco(decoShrub);
-
-        DecoBaseBiomeDecorations decoBaseBiomeDecorations = new DecoBaseBiomeDecorations();
-        decoBaseBiomeDecorations.setNotEqualsZeroChance(3);
-        this.addDeco(decoBaseBiomeDecorations);
-
-        DecoFlowersRTG decoFlowersRTG = new DecoFlowersRTG();
-        decoFlowersRTG.setFlowers(new int[]{3, 6});
-        decoFlowersRTG.setMaxY(128);
-        decoFlowersRTG.setStrengthFactor(12f);
-        this.addDeco(decoFlowersRTG);
-
-        DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
-        decoGrass.setStrengthFactor(20f);
-        this.addDeco(decoGrass);
+        this.addDecoCollection(new DecoCollectionBirchForest(this.getConfig().ALLOW_LOGS.get()));
     }
 }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
@@ -8,19 +8,13 @@ import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.gen.feature.WorldGenTrees;
 
 import rtg.api.config.BiomeConfig;
-import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.world.RTGWorld;
-import rtg.world.biome.deco.*;
-import rtg.world.biome.deco.helper.DecoHelperRandomSplit;
-import rtg.world.gen.feature.tree.rtg.TreeRTG;
-import rtg.world.gen.feature.tree.rtg.TreeRTGBetulaPapyrifera;
+import rtg.world.biome.deco.collection.DecoCollectionBirchForest;
 import rtg.world.gen.surface.SurfaceBase;
 import rtg.world.gen.terrain.TerrainBase;
-import static rtg.world.biome.deco.DecoFallenTree.LogCondition.RANDOM_CHANCE;
 
 public class RealisticBiomeVanillaBirchForestHillsM extends RealisticBiomeVanillaBase {
 
@@ -119,79 +113,6 @@ public class RealisticBiomeVanillaBirchForestHillsM extends RealisticBiomeVanill
 
     @Override
     public void initDecos() {
-
-        TreeRTG birchSmall = new TreeRTGBetulaPapyrifera();
-        birchSmall.setLogBlock(BlockUtil.getStateLog(2));
-        birchSmall.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchSmall.setMinTrunkSize(4);
-        birchSmall.setMaxTrunkSize(10);
-        birchSmall.setMinCrownSize(8);
-        birchSmall.setMaxCrownSize(19);
-        this.addTree(birchSmall);
-
-        DecoTree smallBirch = new DecoTree(birchSmall);
-        smallBirch.setStrengthNoiseFactorForLoops(true);
-        smallBirch.setTreeType(DecoTree.TreeType.RTG_TREE);
-        smallBirch.getDistribution().setNoiseDivisor(80f);
-        smallBirch.getDistribution().setNoiseFactor(60f);
-        smallBirch.getDistribution().setNoiseAddend(-15f);
-        smallBirch.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        smallBirch.setMaxY(120);
-        this.addDeco(smallBirch);
-
-        TreeRTG birchTree = new TreeRTGBetulaPapyrifera();
-        birchTree.setLogBlock(BlockUtil.getStateLog(2));
-        birchTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        birchTree.setMinTrunkSize(4);
-        birchTree.setMaxTrunkSize(10);
-        birchTree.setMinCrownSize(8);
-        birchTree.setMaxCrownSize(19);
-        this.addTree(birchTree);
-
-        DecoTree birchTrees = new DecoTree(birchTree);
-        birchTrees.setStrengthFactorForLoops(3f);
-        birchTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
-        birchTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        birchTrees.setMaxY(100);
-
-        DecoTree rtgTrees = new DecoTree(new WorldGenTrees(false));
-        rtgTrees.setTreeType(DecoTree.TreeType.WORLDGEN);
-        rtgTrees.setStrengthFactorForLoops(3f);
-        rtgTrees.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        rtgTrees.setMaxY(100);
-
-        DecoHelperRandomSplit decoHelperRandomSplit = new DecoHelperRandomSplit();
-        decoHelperRandomSplit.decos = new DecoBase[]{birchTrees, rtgTrees};
-        decoHelperRandomSplit.chances = new int[]{10, 4};
-        this.addDeco(decoHelperRandomSplit);
-
-        DecoFallenTree decoFallenTree = new DecoFallenTree();
-        decoFallenTree.setLogCondition(RANDOM_CHANCE);
-        decoFallenTree.setLogConditionChance(8);
-        decoFallenTree.setLogBlock(BlockUtil.getStateLog(2));
-        decoFallenTree.setLeavesBlock(BlockUtil.getStateLeaf(2));
-        decoFallenTree.setMinSize(3);
-        decoFallenTree.setMaxSize(6);
-        this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
-
-        DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(120);
-        decoShrub.setStrengthFactor(3f);
-        this.addDeco(decoShrub);
-
-        DecoBaseBiomeDecorations decoBaseBiomeDecorations = new DecoBaseBiomeDecorations();
-        decoBaseBiomeDecorations.setNotEqualsZeroChance(3);
-        this.addDeco(decoBaseBiomeDecorations);
-
-        DecoFlowersRTG decoFlowersRTG = new DecoFlowersRTG();
-        decoFlowersRTG.setFlowers(new int[]{3, 6});
-        decoFlowersRTG.setMaxY(128);
-        decoFlowersRTG.setStrengthFactor(12f);
-        this.addDeco(decoFlowersRTG);
-
-        DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
-        decoGrass.setStrengthFactor(20f);
-        this.addDeco(decoGrass);
+        this.addDecoCollection(new DecoCollectionBirchForest(this.getConfig().ALLOW_LOGS.get()));
     }
 }

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -97,6 +97,7 @@ public class ChunkProviderRTG implements IChunkGenerator
     private boolean populating = false;
     private boolean fakeGenerator = false;
     private LimitedSet<ChunkPos> alreadyDecorated = new LimitedSet<>(1000);
+    private ChunkOreGenTracker chunkOreGenTracker = new ChunkOreGenTracker();
     private AnvilChunkLoader chunkLoader;
 
     // we have to store this callback because it's a WeakReference in the event manager
@@ -129,7 +130,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         m.put("distance", "24");
         mapFeaturesEnabled = world.getWorldInfo().isMapFeaturesEnabled();
 
-        boolean isRTGWorld = world.getWorldInfo().getTerrainType() instanceof WorldTypeRTG;
+        boolean isRTGWorld = world.getWorldType() instanceof WorldTypeRTG;
 
         if (isRTGWorld && rtgConfig.ENABLE_CAVE_MODIFICATIONS.get()) {
             caveGenerator = (MapGenCaves) TerrainGen.getModdedMapGen(new MapGenCavesRTG(), EventType.CAVE);
@@ -687,6 +688,9 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start("Decorations");
         MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Pre(worldObj, rand, new BlockPos(worldX, 0, worldZ)));
 
+        // Ore gen.
+        this.generateOres(new BlockPos(worldX, 0, worldZ));
+
         //Initialise variables.
         float river = -cmr.getRiverStrength(worldX + 16, worldZ + 16);
 
@@ -1022,5 +1026,26 @@ public class ChunkProviderRTG implements IChunkGenerator
         synchronized (toDecorate) {
             toDecorate.remove(toAdd);
         }
+    }
+
+    private void generateOres(BlockPos pos) {
+
+        int x = pos.getX();
+        int z = pos.getZ();
+
+        // Have we already generated ores for this chunk?
+        if (chunkOreGenTracker.hasGeneratedOres(pos)) {
+            Logger.debug("Already generated ores for %d %d", x, z);
+            return;
+        }
+
+        Biome bgg = this.worldObj.getBiome(pos);
+        RealisticBiomeBase oreBiome = RealisticBiomeBase.getBiome(Biome.getIdForBiome(bgg));
+        oreBiome.rDecorator.decorateOres(this.worldObj, this.rand, x, z);
+        chunkOreGenTracker.addOreChunk(pos);
+    }
+
+    public ChunkOreGenTracker getChunkOreGenTracker() {
+        return this.chunkOreGenTracker;
     }
 }

--- a/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
+++ b/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
@@ -74,7 +74,7 @@ public class MapGenVillageRTG extends MapGenVillage
 
         if (i == k && j == l) {
 
-            boolean booRTGWorld = worldObj.getWorldInfo().getTerrainType() instanceof WorldTypeRTG;
+            boolean booRTGWorld = worldObj.getWorldType() instanceof WorldTypeRTG;
             boolean booRTGChunkManager = worldObj.getBiomeProvider() instanceof BiomeProviderRTG;
 
             int worldX = i * 16 + 8;

--- a/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
+++ b/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
@@ -122,7 +122,7 @@ public class StructureOceanMonumentRTG extends StructureOceanMonument
     public boolean areBiomesViable(int x, int z, int radius, List<Biome> allowed)
     {
         // Are we in an RTG world?
-        if (!(this.worldObj.getWorldInfo().getTerrainType() instanceof WorldTypeRTG)) {
+        if (!(this.worldObj.getWorldType() instanceof WorldTypeRTG)) {
             //Logger.debug("Could not generate ocean monument. This is not an RTG world.");
             return false;
         }


### PR DESCRIPTION
Ok, this is my attempt at once-per-chunk ore generation... what a minefield!!!

Instead of cancelling all ore gen events by default as we discussed previously, RTG now generates ores *before* other biome decoration takes place and tracks which chunks have had their ores generated. If ore gen  has already occurred for a given chunk, *that's* when the events get cancelled.

@Zeno410 The relevant commits for the ore gen stuff are:

https://github.com/Team-RTG/Realistic-Terrain-Generation/commit/aaafcd818fe0e94e03de5b8962da5831218f721a

and

https://github.com/Team-RTG/Realistic-Terrain-Generation/commit/c1f2b6f232314b0e2f2ed56843f6aba3dc526bdd

Essentially, I've decoupled all ore gen logic from all other biome decoration, so now RTG (and only RTG) is handling ore gen in CPRTG, before other biome decoration takes place. This also negates ore gen in base biome decorations because by the time the base biome decorates itself, ore gen will have already occurred (and will be added to the ChunkOreGenTracker), which means the ore gen events from the base biome will get cancelled because ore gen has already taken place.

The only thing this PR doesn't address is the rabbit-holing we discussed on Discord, so... over to you! :)