### PR TITLE
Volcano speed improvements (cherry-picked from 1.11)

### DIFF
--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -286,7 +286,7 @@ public class ChunkProviderRTG implements IChunkGenerator
                 baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome));
             }
         }
-        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise, landscape.biome[0]);
+        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise);
         TimeTracker.manager.stop(volcanos);
 
         String replace = "RTG Replace";
@@ -294,14 +294,20 @@ public class ChunkProviderRTG implements IChunkGenerator
         replaceBlocksForBiome(cx, cz, primer, landscape.biome, baseBiomesList, landscape.noise);
         TimeTracker.manager.stop(replace);
 
-        caveGenerator.generate(worldObj, cx, cz, primer);
-        ravineGenerator.generate(worldObj, cx, cz, primer);
+        if (Biome.getIdForBiome(baseBiomesList[0])!=0
+                &&Biome.getIdForBiome(baseBiomesList[0])!=32) {
+             caveGenerator.generate(worldObj, cx, cz, primer);
+             ravineGenerator.generate(worldObj, cx, cz, primer);
+        }
 
         if (mapFeaturesEnabled) {
 
             if (rtgConfig.GENERATE_MINESHAFTS.get()) {
                 try {
-                    mineshaftGenerator.generate(this.worldObj, cx, cz, primer);
+                    if (Biome.getIdForBiome(baseBiomesList[0])!=0
+                            &&Biome.getIdForBiome(baseBiomesList[0])!=32) {
+                         mineshaftGenerator.generate(this.worldObj, cx, cz, primer);
+                    }
                 }
                 catch (Exception e) {
                     if (rtgConfig.CRASH_ON_STRUCTURE_EXCEPTIONS.get()) {

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -195,7 +195,6 @@ public class ChunkProviderRTG implements IChunkGenerator
         float[][] weightings = new float[sampleArraySize * sampleArraySize][256];
         for (int i = 0; i < 16; i++) {
             for (int j = 0; j < 16; j++) {
-                TimeTracker.manager.start("Weighting");
                 float limit = (float) Math.pow((56f * 56f), .7);
                 // float limit = 56f;
 
@@ -264,12 +263,20 @@ public class ChunkProviderRTG implements IChunkGenerator
         ChunkPrimer primer = new ChunkPrimer();
         int k;
 
+        String landscaping = "RTG Landscape";
+        TimeTracker.manager.start(landscaping);
         ChunkLandscape landscape = landscapeGenerator.landscape(cmr, cx * 16, cz * 16);
 
+        TimeTracker.manager.stop(landscaping);
+
+        String fill = "RTG Fill";
+        TimeTracker.manager.start(fill);
         generateTerrain(cmr, cx, cz, primer, landscape.biome, landscape.noise);
+        TimeTracker.manager.stop(fill);
         // that routine can change the blocks.
         //get standard biome Data
-
+        String volcanos = "Volcanos";
+        TimeTracker.manager.start(volcanos);
         for (k = 0; k < 256; k++) {
 
             try {
@@ -279,9 +286,13 @@ public class ChunkProviderRTG implements IChunkGenerator
                 baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome));
             }
         }
-        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise);
+        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise, landscape.biome[0]);
+        TimeTracker.manager.stop(volcanos);
 
+        String replace = "RTG Replace";
+        TimeTracker.manager.start(replace);
         replaceBlocksForBiome(cx, cz, primer, landscape.biome, baseBiomesList, landscape.noise);
+        TimeTracker.manager.stop(replace);
 
         caveGenerator.generate(worldObj, cx, cz, primer);
         ravineGenerator.generate(worldObj, cx, cz, primer);

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -293,21 +293,13 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start(replace);
         replaceBlocksForBiome(cx, cz, primer, landscape.biome, baseBiomesList, landscape.noise);
         TimeTracker.manager.stop(replace);
-
-        if (Biome.getIdForBiome(baseBiomesList[0])!=0
-                &&Biome.getIdForBiome(baseBiomesList[0])!=32) {
-             caveGenerator.generate(worldObj, cx, cz, primer);
-             ravineGenerator.generate(worldObj, cx, cz, primer);
-        }
-
+        caveGenerator.generate(worldObj, cx, cz, primer);
+        ravineGenerator.generate(worldObj, cx, cz, primer);
         if (mapFeaturesEnabled) {
 
             if (rtgConfig.GENERATE_MINESHAFTS.get()) {
                 try {
-                    if (Biome.getIdForBiome(baseBiomesList[0])!=0
-                            &&Biome.getIdForBiome(baseBiomesList[0])!=32) {
-                         mineshaftGenerator.generate(this.worldObj, cx, cz, primer);
-                    }
+                    mineshaftGenerator.generate(this.worldObj, cx, cz, primer);
                 }
                 catch (Exception e) {
                     if (rtgConfig.CRASH_ON_STRUCTURE_EXCEPTIONS.get()) {

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -37,7 +37,7 @@ public class VolcanoGenerator {
             l = (mapRand.nextLong() / 2L) * 2L + 1L;
             l1 = (mapRand.nextLong() / 2L) * 2L + 1L;
     }
-    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase biome) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
@@ -57,7 +57,7 @@ public class VolcanoGenerator {
                 if (noVolcano.contains(probe)) continue;
                 noVolcano.add(probe);
                 mapRand.setSeed((long) baseX * l + (long) baseY * l1 ^ seed);
-                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise);
+                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise, biome);
             }
         }
     }
@@ -65,19 +65,18 @@ public class VolcanoGenerator {
     public void rMapVolcanoes(
         ChunkPrimer primer, World world, IBiomeProviderRTG cmr, 
             int baseX, int baseY, int chunkX, int chunkY,
-        OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+        OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase realisticBiome) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
 
         // Have volcanoes been disabled in the biome config?
-        int biomeId = Biome.getIdForBiome(cmr.getBiomeGenAt(baseX * 16, baseY * 16));
-        RealisticBiomeBase realisticBiome = getBiome(biomeId);
+
         // Do we need to patch the biome?
         if (realisticBiome == null) {
             RealisticBiomePatcher biomePatcher = new RealisticBiomePatcher();
             realisticBiome = biomePatcher.getPatchedRealisticBiome(
-                "NULL biome (" + biomeId + ") found when mapping volcanoes.");
+                "NULL biome found when mapping volcanoes.");
         }
         if (!realisticBiome.getConfig().ALLOW_VOLCANOES.get()) return;
 

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -37,7 +37,7 @@ public class VolcanoGenerator {
             l = (mapRand.nextLong() / 2L) * 2L + 1L;
             l1 = (mapRand.nextLong() / 2L) * 2L + 1L;
     }
-    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase biome) {
+    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
@@ -57,7 +57,7 @@ public class VolcanoGenerator {
                 if (noVolcano.contains(probe)) continue;
                 noVolcano.add(probe);
                 mapRand.setSeed((long) baseX * l + (long) baseY * l1 ^ seed);
-                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise, biome);
+                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise);
             }
         }
     }
@@ -65,29 +65,28 @@ public class VolcanoGenerator {
     public void rMapVolcanoes(
         ChunkPrimer primer, World world, IBiomeProviderRTG cmr, 
             int baseX, int baseY, int chunkX, int chunkY,
-        OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase realisticBiome) {
+        OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
 
-        // Have volcanoes been disabled in the biome config?
+        // Let's go ahead and generate the volcano. Exciting!!! :D
+        if (baseX % 4 == 0 && baseY % 4 == 0) {
+            int biomeId = Biome.getIdForBiome(cmr.getBiomeGenAt(baseX * 16, baseY * 16));
+            RealisticBiomeBase realisticBiome = getBiome(biomeId);
 
-        // Do we need to patch the biome?
-        if (realisticBiome == null) {
-            RealisticBiomePatcher biomePatcher = new RealisticBiomePatcher();
-            realisticBiome = biomePatcher.getPatchedRealisticBiome(
-                "NULL biome found when mapping volcanoes.");
-        }
-        if (!realisticBiome.getConfig().ALLOW_VOLCANOES.get()) return;
-
-        // Have volcanoes been disabled via frequency?
-        // Use the global frequency unless the biome frequency has been explicitly set.
-        int chance = realisticBiome.getConfig().VOLCANO_CHANCE.get() == -1 ? rtgConfig.VOLCANO_CHANCE.get() : realisticBiome.getConfig().VOLCANO_CHANCE.get();
-        if (chance < 1) return;
-
-        // If we've made it this far, let's go ahead and generate the volcano. Exciting!!! :D
-        
-        if (baseX % 4 == 0 && baseY % 4 == 0 && mapRand.nextInt(chance) == 0) {
+            // Do we need to patch the biome?
+            if (realisticBiome == null) {
+                RealisticBiomePatcher biomePatcher = new RealisticBiomePatcher();
+                realisticBiome = biomePatcher.getPatchedRealisticBiome(
+                    "NULL biome found when mapping volcanoes.");
+            }
+            if (!realisticBiome.getConfig().ALLOW_VOLCANOES.get()) return;
+            // Have volcanoes been disabled via frequency?
+            // Use the global frequency unless the biome frequency has been explicitly set.
+            int chance = realisticBiome.getConfig().VOLCANO_CHANCE.get() == -1 ? rtgConfig.VOLCANO_CHANCE.get() : realisticBiome.getConfig().VOLCANO_CHANCE.get();
+            if (chance < 1) return;
+            if (mapRand.nextInt(chance)>0) return;
 
             float river = cmr.getRiverStrength(baseX * 16, baseY * 16) + 1f;
             if (river > 0.98f && cmr.isBorderlessAt(baseX * 16, baseY * 16)) {

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -1,0 +1,108 @@
+package rtg.world.gen;
+
+import java.util.Random;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkPrimer;
+import rtg.api.RTGAPI;
+import rtg.api.config.RTGConfig;
+import rtg.api.util.LimitedSet;
+import rtg.api.util.noise.CellNoise;
+import rtg.api.util.noise.OpenSimplexNoise;
+import rtg.world.biome.IBiomeProviderRTG;
+import rtg.world.biome.realistic.RealisticBiomeBase;
+import static rtg.world.biome.realistic.RealisticBiomeBase.getBiome;
+import rtg.world.biome.realistic.RealisticBiomePatcher;
+import rtg.world.gen.feature.WorldGenVolcano;
+
+/**
+ *
+ * @author Zeno410
+ */
+public class VolcanoGenerator {
+    
+    private Random mapRand;
+    private long seed;
+    protected RTGConfig rtgConfig = RTGAPI.config();
+    private static long l;
+    private static long l1;
+    
+    private static LimitedSet<ChunkPos> noVolcano = new LimitedSet<>(2000);
+    
+    public VolcanoGenerator(long seed) {
+        this.seed = seed;
+        mapRand = new Random(seed);
+            mapRand.setSeed(seed);
+            l = (mapRand.nextLong() / 2L) * 2L + 1L;
+            l1 = (mapRand.nextLong() / 2L) * 2L + 1L;
+    }
+    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+
+        // Have volcanoes been disabled in the global config?
+        if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
+
+        final int mapGenRadius = 5;
+        final int volcanoGenRadius = 15;
+
+        //if (!seed.equals(currentSeed)) {
+            //currentSeed = seed;
+        //}
+
+
+        // Volcanoes generation
+        for (int baseX = chunkX - volcanoGenRadius; baseX <= chunkX + volcanoGenRadius; baseX++) {
+            for (int baseY = chunkY - volcanoGenRadius; baseY <= chunkY + volcanoGenRadius; baseY++) {
+                ChunkPos probe = new ChunkPos(baseX,baseY);
+                if (noVolcano.contains(probe)) continue;
+                noVolcano.add(probe);
+                mapRand.setSeed((long) baseX * l + (long) baseY * l1 ^ seed);
+                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise);
+            }
+        }
+    }
+    
+    public void rMapVolcanoes(
+        ChunkPrimer primer, World world, IBiomeProviderRTG cmr, 
+            int baseX, int baseY, int chunkX, int chunkY,
+        OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+
+        // Have volcanoes been disabled in the global config?
+        if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
+
+        // Have volcanoes been disabled in the biome config?
+        int biomeId = Biome.getIdForBiome(cmr.getBiomeGenAt(baseX * 16, baseY * 16));
+        RealisticBiomeBase realisticBiome = getBiome(biomeId);
+        // Do we need to patch the biome?
+        if (realisticBiome == null) {
+            RealisticBiomePatcher biomePatcher = new RealisticBiomePatcher();
+            realisticBiome = biomePatcher.getPatchedRealisticBiome(
+                "NULL biome (" + biomeId + ") found when mapping volcanoes.");
+        }
+        if (!realisticBiome.getConfig().ALLOW_VOLCANOES.get()) return;
+
+        // Have volcanoes been disabled via frequency?
+        // Use the global frequency unless the biome frequency has been explicitly set.
+        int chance = realisticBiome.getConfig().VOLCANO_CHANCE.get() == -1 ? rtgConfig.VOLCANO_CHANCE.get() : realisticBiome.getConfig().VOLCANO_CHANCE.get();
+        if (chance < 1) return;
+
+        // If we've made it this far, let's go ahead and generate the volcano. Exciting!!! :D
+        
+        if (baseX % 4 == 0 && baseY % 4 == 0 && mapRand.nextInt(chance) == 0) {
+
+            float river = cmr.getRiverStrength(baseX * 16, baseY * 16) + 1f;
+            if (river > 0.98f && cmr.isBorderlessAt(baseX * 16, baseY * 16)) {
+                
+                 // we have to pull it out of noVolcano. We do it this way to avoid having to make a ChunkPos twice
+                ChunkPos probe = new ChunkPos(baseX,baseY);
+                noVolcano.remove(probe);
+                
+                long i1 = mapRand.nextLong() / 2L * 2L + 1L;
+                long j1 = mapRand.nextLong() / 2L * 2L + 1L;
+                mapRand.setSeed((long) chunkX * i1 + (long) chunkY * j1 ^ world.getSeed());
+
+                WorldGenVolcano.build(primer, world, mapRand, baseX, baseY, chunkX, chunkY, simplex, cell, noise);
+            }
+        }
+    }
+}


### PR DESCRIPTION
About 50 times as fast, from about half the CPU consumption of terrain
generation to a minor effect. Also, we get to skip a lot of biome
lookups which might speed things a little more.

(cherry picked from commit 348442480fa71584b917491b40997f13cdf54c03)