### PR TITLE
Further volcano speed improvements

### DIFF
--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -201,7 +201,6 @@ public class ChunkProviderRTG implements IChunkGenerator
         float[][] weightings = new float[sampleArraySize * sampleArraySize][256];
         for (int i = 0; i < 16; i++) {
             for (int j = 0; j < 16; j++) {
-                TimeTracker.manager.start("Weighting");
                 float limit = (float) Math.pow((56f * 56f), .7);
                 // float limit = 56f;
 
@@ -269,12 +268,20 @@ public class ChunkProviderRTG implements IChunkGenerator
         ChunkPrimer primer = new ChunkPrimer();
         int k;
 
+        String landscaping = "RTG Landscape";
+        TimeTracker.manager.start(landscaping);
         ChunkLandscape landscape = landscapeGenerator.landscape(cmr, cx * 16, cz * 16);
 
+        TimeTracker.manager.stop(landscaping);
+        
+        String fill = "RTG Fill";
+        TimeTracker.manager.start(fill);
         generateTerrain(cmr, cx, cz, primer, landscape.biome, landscape.noise);
+        TimeTracker.manager.stop(fill);
         // that routine can change the blocks.
         //get standard biome Data
-
+        String volcanos = "Volcanos";
+        TimeTracker.manager.start(volcanos);
         for (k = 0; k < 256; k++) {
 
             try {
@@ -284,9 +291,13 @@ public class ChunkProviderRTG implements IChunkGenerator
                 baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome));
             }
         }
-        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise);
+        volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise, landscape.biome[0]);
+        TimeTracker.manager.stop(volcanos);
         
+        String replace = "RTG Replace";
+        TimeTracker.manager.start(replace);
         replaceBlocksForBiome(cx, cz, primer, landscape.biome, baseBiomesList, landscape.noise);
+        TimeTracker.manager.stop(replace);
 
         caveGenerator.generate(worldObj, cx, cz, primer);
         ravineGenerator.generate(worldObj, cx, cz, primer);

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -37,7 +37,7 @@ public class VolcanoGenerator {
             l = (mapRand.nextLong() / 2L) * 2L + 1L;
             l1 = (mapRand.nextLong() / 2L) * 2L + 1L;
     }
-    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+    public void generateMapGen(ChunkPrimer primer, Long unusedSeed, World world, IBiomeProviderRTG cmr, Random unusedMapRand, int chunkX, int chunkY, OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase biome) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
@@ -57,7 +57,7 @@ public class VolcanoGenerator {
                 if (noVolcano.contains(probe)) continue;
                 noVolcano.add(probe);
                 mapRand.setSeed((long) baseX * l + (long) baseY * l1 ^ seed);
-                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise);
+                rMapVolcanoes(primer, world, cmr, baseX, baseY, chunkX, chunkY, simplex, cell, noise, biome);
             }
         }
     }
@@ -65,19 +65,18 @@ public class VolcanoGenerator {
     public void rMapVolcanoes(
         ChunkPrimer primer, World world, IBiomeProviderRTG cmr, 
             int baseX, int baseY, int chunkX, int chunkY,
-        OpenSimplexNoise simplex, CellNoise cell, float noise[]) {
+        OpenSimplexNoise simplex, CellNoise cell, float noise[], RealisticBiomeBase realisticBiome) {
 
         // Have volcanoes been disabled in the global config?
         if (!rtgConfig.ENABLE_VOLCANOES.get()) return;
 
         // Have volcanoes been disabled in the biome config?
-        int biomeId = Biome.getIdForBiome(cmr.getBiomeGenAt(baseX * 16, baseY * 16));
-        RealisticBiomeBase realisticBiome = getBiome(biomeId);
+ 
         // Do we need to patch the biome?
         if (realisticBiome == null) {
             RealisticBiomePatcher biomePatcher = new RealisticBiomePatcher();
             realisticBiome = biomePatcher.getPatchedRealisticBiome(
-                "NULL biome (" + biomeId + ") found when mapping volcanoes.");
+                "NULL biome found when mapping volcanoes.");
         }
         if (!realisticBiome.getConfig().ALLOW_VOLCANOES.get()) return;
 


### PR DESCRIPTION
Removed a call to the GenLayer stack deep in a loop. This reduces the
time for volcano checks to a minimal level (0.1% of cpu in my last
flying test).

 Also added some timing trackers.