### PR TITLE
Biome-configurable biome temperatures.

### DIFF
--- a/src/main/java/rtg/api/config/BiomeConfig.java
+++ b/src/main/java/rtg/api/config/BiomeConfig.java
@@ -30,7 +30,6 @@ public class BiomeConfig extends Config {
     public final ConfigPropertyInt RAVINE_FREQUENCY;
     public final ConfigPropertyInt BEACH_BIOME;
     public final ConfigPropertyFloat TREE_DENSITY_MULTIPLIER;
-    public final ConfigPropertyInt MIN_Y_COORD_FOR_SNOW_LAYERS;
 
     /*
      * OPTIONAL CONFIGS
@@ -287,21 +286,6 @@ public class BiomeConfig extends Config {
             -1.0f, -1.0f, 5.0f
         );
         this.addProperty(TREE_DENSITY_MULTIPLIER);
-
-        MIN_Y_COORD_FOR_SNOW_LAYERS = new ConfigPropertyInt(
-            Type.INTEGER,
-            "Minimum Y Coord for Snow Layers",
-            "Snow",
-            "Snow layers in this biome will not generate below this Y coord."
-                + Configuration.NEW_LINE +
-                "For example, snow generates around Y=95 in Extreme Hills. If you'd rather have snow generate from Y=110 and higher, set this to 110."
-                + Configuration.NEW_LINE +
-                "Set to -1 to use this biome's default snow settings."
-                + Configuration.NEW_LINE +
-                "This applies to newly-generated chunks only. Snow layers will still appear in cold/snowy biomes after it snows.",
-            -1, 1, 255
-        );
-        this.addProperty(MIN_Y_COORD_FOR_SNOW_LAYERS);
 
         /*
          * OPTIONAL CONFIGS

--- a/src/main/java/rtg/api/config/BiomeConfig.java
+++ b/src/main/java/rtg/api/config/BiomeConfig.java
@@ -30,6 +30,7 @@ public class BiomeConfig extends Config {
     public final ConfigPropertyInt RAVINE_FREQUENCY;
     public final ConfigPropertyInt BEACH_BIOME;
     public final ConfigPropertyFloat TREE_DENSITY_MULTIPLIER;
+    public final ConfigPropertyString TEMPERATURE;
 
     /*
      * OPTIONAL CONFIGS
@@ -50,7 +51,6 @@ public class BiomeConfig extends Config {
     public final ConfigPropertyInt WHEAT_CHANCE;
     public final ConfigPropertyInt WHEAT_MIN_Y;
     public final ConfigPropertyInt WHEAT_MAX_Y;
-    public final ConfigPropertyString TEMPERATURE;
 
     public BiomeConfig() {
 
@@ -288,6 +288,23 @@ public class BiomeConfig extends Config {
         );
         this.addProperty(TREE_DENSITY_MULTIPLIER);
 
+        TEMPERATURE = new ConfigPropertyString(
+            Type.STRING,
+            "Temperature",
+            "Biome Properties",
+            "If you want to change this biome's temperature, enter a valid value here. [range: -2.0 ~ 2.0]"
+                + Configuration.NEW_LINE +
+                "In keeping with vanilla's temperature validation rules, values in the range of 0.1 to 0.2 (non-inclusive) are not valid and will result in a crash on startup."
+                + Configuration.NEW_LINE +
+                "If this value is empty, the biome's default temperature will be used."
+                + Configuration.NEW_LINE +
+                "Please note that changing a biome's temperature does NOT affect its climate type (DESERT, WARM, COOL, ICY)."
+                + Configuration.NEW_LINE +
+                "For more info, visit http://minecraft.gamepedia.com/Biome#Temperature",
+            ""
+        );
+        this.addProperty(TEMPERATURE);
+
         /*
          * OPTIONAL CONFIGS
          *
@@ -365,23 +382,6 @@ public class BiomeConfig extends Config {
                 "For more info, visit http://minecraft.gamepedia.com/Data_values",
             0, 0, 15
         );
-
-        TEMPERATURE = new ConfigPropertyString(
-            Type.STRING,
-            "Temperature",
-            "Biome Properties",
-            "If you want to change this biome's temperature, enter a valid value here. [range: -2.0 ~ 2.0]"
-                + Configuration.NEW_LINE +
-                "In keeping with vanilla's temperature validation rules, values in the range of 0.1 to 0.2 (non-inclusive) are not valid and will result in a crash on startup."
-                + Configuration.NEW_LINE +
-                "If this value is empty, the biome's default temperature will be used."
-                + Configuration.NEW_LINE +
-                "Please note that changing a biome's temperature does NOT affect its climate type (DESERT, WARM, COOL, ICY)."
-                + Configuration.NEW_LINE +
-                "For more info, visit http://minecraft.gamepedia.com/Biome#Temperature",
-            ""
-        );
-        this.addProperty(TEMPERATURE);
 
         ALLOW_LOGS = new ConfigPropertyBoolean(ConfigProperty.Type.BOOLEAN, "Allow Logs", "Decorations.Logs", "", true);
         ALLOW_PALM_TREES = new ConfigPropertyBoolean(Type.BOOLEAN, "Allow Palm Trees", "Decorations.Palm Trees", "", true);

--- a/src/main/java/rtg/api/config/BiomeConfig.java
+++ b/src/main/java/rtg/api/config/BiomeConfig.java
@@ -50,6 +50,7 @@ public class BiomeConfig extends Config {
     public final ConfigPropertyInt WHEAT_CHANCE;
     public final ConfigPropertyInt WHEAT_MIN_Y;
     public final ConfigPropertyInt WHEAT_MAX_Y;
+    public final ConfigPropertyString TEMPERATURE;
 
     public BiomeConfig() {
 
@@ -364,6 +365,23 @@ public class BiomeConfig extends Config {
                 "For more info, visit http://minecraft.gamepedia.com/Data_values",
             0, 0, 15
         );
+
+        TEMPERATURE = new ConfigPropertyString(
+            Type.STRING,
+            "Temperature",
+            "Biome Properties",
+            "If you want to change this biome's temperature, enter a valid value here. [range: -2.0 ~ 2.0]"
+                + Configuration.NEW_LINE +
+                "In keeping with vanilla's temperature validation rules, values in the range of 0.1 to 0.2 (non-inclusive) are not valid and will result in a crash on startup."
+                + Configuration.NEW_LINE +
+                "If this value is empty, the biome's default temperature will be used."
+                + Configuration.NEW_LINE +
+                "Please note that changing a biome's temperature does NOT affect its climate type (DESERT, WARM, COOL, ICY)."
+                + Configuration.NEW_LINE +
+                "For more info, visit http://minecraft.gamepedia.com/Biome#Temperature",
+            ""
+        );
+        this.addProperty(TEMPERATURE);
 
         ALLOW_LOGS = new ConfigPropertyBoolean(ConfigProperty.Type.BOOLEAN, "Allow Logs", "Decorations.Logs", "", true);
         ALLOW_PALM_TREES = new ConfigPropertyBoolean(Type.BOOLEAN, "Allow Palm Trees", "Decorations.Palm Trees", "", true);

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -586,10 +586,15 @@ public abstract class RealisticBiomeBase {
                 throw new RuntimeException("Biome temperature out of range for " + biomeName + ".");
             }
 
-            Accessor<Biome, Float> biomeTemp = new Accessor<>("temperature");
-            biomeTemp.setField(biome, biomeTemperature);
+            try {
+                Accessor<Biome, Float> biomeTemp = new Accessor<>("temperature");
+                biomeTemp.setField(biome, biomeTemperature);
 
-            Logger.info("Set biome temperature to %f for %s", biomeTemperature, biomeName);
+                Logger.info("Set biome temperature to %f for %s", biomeTemperature, biomeName);
+            }
+            catch (Exception e) {
+                Logger.warn("Unable to set biome temperature to %f for %s.", biomeTemperature, biomeName);
+            }
         }
     }
 

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -14,11 +14,13 @@ import rtg.RTG;
 import rtg.api.RTGAPI;
 import rtg.api.config.BiomeConfig;
 import rtg.api.config.RTGConfig;
+import rtg.api.util.Accessor;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexCellularNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.world.RTGWorld;
+import rtg.util.Logger;
 import rtg.util.SaplingUtil;
 import rtg.world.biome.BiomeAnalyzer;
 import rtg.world.biome.BiomeDecoratorRTG;
@@ -129,6 +131,7 @@ public abstract class RealisticBiomeBase {
     private void init() {
         initConfig();
         this.getConfig().load(this.configPath());
+        this.adjustBiomeProperties();
         this.terrain = initTerrain();
         this.surface = initSurface();
         this.surfaceRiver = new SurfaceRiverOasis(config);
@@ -559,6 +562,35 @@ public abstract class RealisticBiomeBase {
         }
 
         return true;
+    }
+
+    private void adjustBiomeProperties() {
+
+        Biome biome = this.baseBiome;
+        int biomeId = Biome.getIdForBiome(biome);
+        String biomeName = biome.getBiomeName();
+
+        // Temperature.
+
+        String configTemperature = this.getConfig().TEMPERATURE.get();
+
+        if (!configTemperature.isEmpty()) {
+
+            float biomeTemperature = Float.valueOf(configTemperature);
+
+            if (biomeTemperature > 0.1f && biomeTemperature < 0.2f)
+            {
+                throw new RuntimeException("Invalid biome temperature for " + biomeName + ".");
+            }
+            else if (biomeTemperature < -2f || biomeTemperature > 2f) {
+                throw new RuntimeException("Biome temperature out of range for " + biomeName + ".");
+            }
+
+            Accessor<Biome, Float> biomeTemp = new Accessor<>("temperature");
+            biomeTemp.setField(biome, biomeTemperature);
+
+            Logger.info("Set biome temperature to %f for %s", biomeTemperature, biomeName);
+        }
     }
 
     public String configPath() {

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -587,13 +587,13 @@ public abstract class RealisticBiomeBase {
             }
 
             try {
-                Accessor<Biome, Float> biomeTemp = new Accessor<>("temperature");
+                Accessor<Biome, Float> biomeTemp = new Accessor<>("temperature", "field_76750_F");
                 biomeTemp.setField(biome, biomeTemperature);
 
                 Logger.info("Set biome temperature to %f for %s", biomeTemperature, biomeName);
             }
             catch (Exception e) {
-                Logger.warn("Unable to set biome temperature to %f for %s.", biomeTemperature, biomeName);
+                Logger.warn("Unable to set biome temperature to %f for %s. Reason: %s", biomeTemperature, biomeName, e.getMessage());
             }
         }
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
@@ -42,6 +42,8 @@ public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK_META).set(0);
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_FILLER_BLOCK).set("");
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_FILLER_BLOCK_META).set(0);
+
+        this.getConfig().TEMPERATURE.set("0.25");
     }
 
     @Override

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
@@ -45,6 +45,8 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK_META).set(0);
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_FILLER_BLOCK).set("");
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_FILLER_BLOCK_META).set(0);
+
+        this.getConfig().TEMPERATURE.set("0.25");
     }
 
     @Override

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
@@ -40,6 +40,8 @@ public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBas
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK_META).set(0);
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_2_BLOCK).set("");
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_2_BLOCK_META).set(0);
+
+        this.getConfig().TEMPERATURE.set("0.25");
     }
 
     @Override

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
@@ -43,6 +43,8 @@ public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanilla
 
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK).set("");
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK_META).set(0);
+
+        this.getConfig().TEMPERATURE.set("0.25");
     }
 
     @Override

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
@@ -41,6 +41,8 @@ public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanill
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_BLOCK_META).set(0);
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_2_BLOCK).set("");
         this.getConfig().addProperty(this.getConfig().SURFACE_MIX_2_BLOCK_META).set(0);
+
+        this.getConfig().TEMPERATURE.set("0.25");
     }
 
     @Override

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -759,7 +759,6 @@ public class ChunkProviderRTG implements IChunkGenerator
 
                     BlockPos snowPos = this.worldObj.getPrecipitationHeight(new BlockPos(worldX + i4, 0, worldZ + j4));
                     BlockPos icePos = snowPos.down();
-                    int snowLayerMinY = biome.getConfig().MIN_Y_COORD_FOR_SNOW_LAYERS.get();
 
                     // Ice.
                     if(this.worldObj.canBlockFreezeWater(icePos)) {
@@ -767,19 +766,6 @@ public class ChunkProviderRTG implements IChunkGenerator
                     }
 
                     // Snow.
-
-                    // Does this biome have custom snow layer settings?
-                    if (snowLayerMinY > -1) {
-
-                        // Let's use a little noise to make sure the snow line isn't flat.
-                        float snowNoise = rtgWorld.simplex.noise3(worldX, snowPos.getY(), worldZ);
-                        snowLayerMinY = snowNoise < -0.8f ? snowLayerMinY - 2 : (snowNoise < -0.3f ? snowLayerMinY - 1 : (snowNoise < 0.3f ? snowLayerMinY : (snowNoise < 8f ? snowLayerMinY + 1 : snowLayerMinY + 2)));
-
-                        if (snowPos.getY() < snowLayerMinY) {
-                            break;
-                        }
-                    }
-
                     if (rtgConfig.ENABLE_SNOW_LAYERS.get() && this.worldUtil.canSnowAt(snowPos, true)) {
                         this.worldObj.setBlockState(snowPos, snowLayerBlock, 2);
                     }


### PR DESCRIPTION
Ok, so... I got rid of the `MIN_Y_COORD_FOR_SNOW_LAYERS` *global* config option and replaced it with a `TEMPERATURE` *biome* config option.

This config option is available to all biomes, but the only biomes that RTG changes by default are the Extreme Hills variants, changing the temperature from 0.2 to 0.25, resulting in snow layers being generated at around Y=120 instead of Y=90. This works when the chunk is initially generated and also when it rains.

The magic happens during `RBB#init` via `RBB#adjustBiomeProperties`, which is the earliest that it can happen given that it's biome-configurable. However, I'm slightly concerned that it won't be early enough for mods that query biome temperature.

But I guess we can cross that bridge if we come to it?