### PR TITLE
Added support for non-Overworld dimensions

### DIFF
--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -49,7 +49,6 @@ import rtg.world.gen.structure.MapGenStrongholdRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
 import rtg.world.gen.structure.StructureOceanMonumentRTG;
 import static rtg.api.RTGAPI.config;
-import static rtg.api.dimension.DimensionManagerRTG.rtgDimensions;
 
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -81,7 +80,7 @@ public class RTG {
 
         worldtype = new WorldTypeRTG(ModInfo.WORLD_TYPE);
 
-        rtgDimensions.add(DimensionManagerRTG.OVERWORLD);
+        DimensionManagerRTG.addRTGDimension(DimensionManagerRTG.OVERWORLD);
 
         configPath = event.getModConfigurationDirectory() + File.separator + ModInfo.CONFIG_DIRECTORY + File.separator;
         RTGAPI.rtgConfig = new RTGConfig();

--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.event.EventManagerRTG;
 import rtg.event.WorldTypeMessageEventHandler;
 import rtg.proxy.ClientProxy;
@@ -48,6 +49,7 @@ import rtg.world.gen.structure.MapGenStrongholdRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
 import rtg.world.gen.structure.StructureOceanMonumentRTG;
 import static rtg.api.RTGAPI.config;
+import static rtg.api.dimension.DimensionManagerRTG.rtgDimensions;
 
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -78,6 +80,8 @@ public class RTG {
         instance = this;
 
         worldtype = new WorldTypeRTG(ModInfo.WORLD_TYPE);
+
+        rtgDimensions.add(DimensionManagerRTG.OVERWORLD);
 
         configPath = event.getModConfigurationDirectory() + File.separator + ModInfo.CONFIG_DIRECTORY + File.separator;
         RTGAPI.rtgConfig = new RTGConfig();

--- a/src/main/java/rtg/api/config/RTGConfig.java
+++ b/src/main/java/rtg/api/config/RTGConfig.java
@@ -74,6 +74,14 @@ public class RTGConfig extends Config {
     public final ConfigPropertyBoolean CRASH_ON_STRUCTURE_EXCEPTIONS;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Dimensions
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    public final ConfigPropertyBoolean USE_DIMENSION_WHITELIST;
+    public final ConfigPropertyString DIMENSION_WHITELIST;
+    public final ConfigPropertyString DIMENSION_BLACKLIST;
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Dunes
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -444,6 +452,41 @@ public class RTGConfig extends Config {
             false
         );
         this.addProperty(CRASH_ON_STRUCTURE_EXCEPTIONS);
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // Dimensions
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        USE_DIMENSION_WHITELIST = new ConfigPropertyBoolean(
+            ConfigProperty.Type.BOOLEAN,
+            "Use Dimension Whitelist",
+            "Dimensions",
+            "If TRUE, then RTG will use the Dimension Whitelist. If FALSE, then RTG will use the Dimension Blacklist.",
+            false
+        );
+        this.addProperty(USE_DIMENSION_WHITELIST);
+
+        DIMENSION_WHITELIST = new ConfigPropertyString(
+            ConfigProperty.Type.STRING,
+            "Dimension Whitelist",
+            "Dimensions",
+            "Comma-separated list of dimension IDs in which RTG is ALLOWED to generate realistic terrain."
+                + Configuration.NEW_LINE +
+                "In order for this setting to have an effect, 'Use Dimension Whitelist' must be set to TRUE.",
+            "0"
+        );
+        this.addProperty(DIMENSION_WHITELIST);
+
+        DIMENSION_BLACKLIST = new ConfigPropertyString(
+            ConfigProperty.Type.STRING,
+            "Dimension Blacklist",
+            "Dimensions",
+            "Comma-separated list of dimension IDs in which RTG is NOT ALLOWED to generate realistic terrain."
+                + Configuration.NEW_LINE +
+                "In order for this setting to have an effect, 'Use Dimension Whitelist' must be set to FALSE.",
+            "-1,1"
+        );
+        this.addProperty(DIMENSION_BLACKLIST);
 
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Dunes
@@ -1480,5 +1523,35 @@ public class RTGConfig extends Config {
         }
 
         return materials;
+    }
+
+    public ArrayList<Integer> getConfigDimensionIds(boolean useDimensionWhitelist)
+    {
+        String configString = useDimensionWhitelist ? DIMENSION_WHITELIST.get() : DIMENSION_BLACKLIST.get();
+        String[] strings = configString.split(",");
+        ArrayList<Integer> intList = new ArrayList<Integer>(){};
+
+        for (int i = 0; i < strings.length; i++) {
+            strings[i] = strings[i].trim();
+            intList.add(Integer.valueOf(strings[i]));
+        }
+
+        return intList;
+    }
+
+    public boolean isValidDimension(int dimensionId) {
+
+        // This variable will contain either whitelisted IDs or blacklisted IDs.
+        ArrayList<Integer> dimensions = this.getConfigDimensionIds(USE_DIMENSION_WHITELIST.get());
+
+        for (int i = 0; i < dimensions.size(); i++) {
+            if (dimensions.get(i) == dimensionId) {
+                // If we have whitelisted IDs, we want to return true.
+                // If we have blacklisted IDs, we want to return false.
+                return USE_DIMENSION_WHITELIST.get();
+            }
+        }
+
+        return !USE_DIMENSION_WHITELIST.get();
     }
 }

--- a/src/main/java/rtg/api/config/RTGConfig.java
+++ b/src/main/java/rtg/api/config/RTGConfig.java
@@ -74,14 +74,6 @@ public class RTGConfig extends Config {
     public final ConfigPropertyBoolean CRASH_ON_STRUCTURE_EXCEPTIONS;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Dimensions
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    public final ConfigPropertyBoolean USE_DIMENSION_WHITELIST;
-    public final ConfigPropertyString DIMENSION_WHITELIST;
-    public final ConfigPropertyString DIMENSION_BLACKLIST;
-
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Dunes
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -452,41 +444,6 @@ public class RTGConfig extends Config {
             false
         );
         this.addProperty(CRASH_ON_STRUCTURE_EXCEPTIONS);
-
-        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        // Dimensions
-        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-        USE_DIMENSION_WHITELIST = new ConfigPropertyBoolean(
-            ConfigProperty.Type.BOOLEAN,
-            "Use Dimension Whitelist",
-            "Dimensions",
-            "If TRUE, then RTG will use the Dimension Whitelist. If FALSE, then RTG will use the Dimension Blacklist.",
-            false
-        );
-        this.addProperty(USE_DIMENSION_WHITELIST);
-
-        DIMENSION_WHITELIST = new ConfigPropertyString(
-            ConfigProperty.Type.STRING,
-            "Dimension Whitelist",
-            "Dimensions",
-            "Comma-separated list of dimension IDs in which RTG is ALLOWED to generate realistic terrain."
-                + Configuration.NEW_LINE +
-                "In order for this setting to have an effect, 'Use Dimension Whitelist' must be set to TRUE.",
-            "0"
-        );
-        this.addProperty(DIMENSION_WHITELIST);
-
-        DIMENSION_BLACKLIST = new ConfigPropertyString(
-            ConfigProperty.Type.STRING,
-            "Dimension Blacklist",
-            "Dimensions",
-            "Comma-separated list of dimension IDs in which RTG is NOT ALLOWED to generate realistic terrain."
-                + Configuration.NEW_LINE +
-                "In order for this setting to have an effect, 'Use Dimension Whitelist' must be set to FALSE.",
-            "-1,1"
-        );
-        this.addProperty(DIMENSION_BLACKLIST);
 
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Dunes
@@ -1523,35 +1480,5 @@ public class RTGConfig extends Config {
         }
 
         return materials;
-    }
-
-    public ArrayList<Integer> getConfigDimensionIds(boolean useDimensionWhitelist)
-    {
-        String configString = useDimensionWhitelist ? DIMENSION_WHITELIST.get() : DIMENSION_BLACKLIST.get();
-        String[] strings = configString.split(",");
-        ArrayList<Integer> intList = new ArrayList<Integer>(){};
-
-        for (int i = 0; i < strings.length; i++) {
-            strings[i] = strings[i].trim();
-            intList.add(Integer.valueOf(strings[i]));
-        }
-
-        return intList;
-    }
-
-    public boolean isValidDimension(int dimensionId) {
-
-        // This variable will contain either whitelisted IDs or blacklisted IDs.
-        ArrayList<Integer> dimensions = this.getConfigDimensionIds(USE_DIMENSION_WHITELIST.get());
-
-        for (int i = 0; i < dimensions.size(); i++) {
-            if (dimensions.get(i) == dimensionId) {
-                // If we have whitelisted IDs, we want to return true.
-                // If we have blacklisted IDs, we want to return false.
-                return USE_DIMENSION_WHITELIST.get();
-            }
-        }
-
-        return !USE_DIMENSION_WHITELIST.get();
     }
 }

--- a/src/main/java/rtg/api/dimension/DimensionManagerRTG.java
+++ b/src/main/java/rtg/api/dimension/DimensionManagerRTG.java
@@ -5,10 +5,10 @@ import java.util.ArrayList;
 /**
  * Created by WhichOnesPink on 28/05/2017.
  */
-public class DimensionManagerRTG {
+public abstract class DimensionManagerRTG {
 
     public static final int OVERWORLD = 0;
-    public static ArrayList<Integer> rtgDimensions = new ArrayList<Integer>(){};
+    private static ArrayList<Integer> rtgDimensions = new ArrayList<Integer>(){};
 
     public static void addRTGDimension(int dimId) {
 

--- a/src/main/java/rtg/api/dimension/DimensionManagerRTG.java
+++ b/src/main/java/rtg/api/dimension/DimensionManagerRTG.java
@@ -1,0 +1,23 @@
+package rtg.api.dimension;
+
+import java.util.ArrayList;
+
+/**
+ * Created by WhichOnesPink on 28/05/2017.
+ */
+public class DimensionManagerRTG {
+
+    public static final int OVERWORLD = 0;
+    public static ArrayList<Integer> rtgDimensions = new ArrayList<Integer>(){};
+
+    public static void addRTGDimension(int dimId) {
+
+        if (!rtgDimensions.contains(dimId)) {
+            rtgDimensions.add(dimId);
+        }
+    }
+
+    public static boolean isValidDimension(int dimId) {
+        return rtgDimensions.contains(dimId);
+    }
+}

--- a/src/main/java/rtg/api/util/DimensionUtil.java
+++ b/src/main/java/rtg/api/util/DimensionUtil.java
@@ -1,0 +1,49 @@
+package rtg.api.util;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Map;
+
+import net.minecraft.world.DimensionType;
+
+import net.minecraftforge.common.DimensionManager;
+
+/**
+ * Created by WhichOnesPink on 28/05/2017.
+ */
+public class DimensionUtil {
+
+    private Hashtable<Integer, DimensionType> registeredDimensions;
+
+    public DimensionUtil() {
+
+        try {
+            Field field = DimensionManager.class.getDeclaredField("dimensions");
+            field.setAccessible(true);
+
+            try {
+                registeredDimensions = (Hashtable<Integer, DimensionType>) field.get(null);
+            }
+            catch (IllegalAccessException e) {
+                throw new RuntimeException("Could not get dimensions.");
+            }
+        }
+        catch (NoSuchFieldException e) {
+            throw new RuntimeException("No dimensions? Hmmmm.");
+        }
+
+    }
+
+    public int[] getRegisteredDimensions()
+    {
+        int[] ret = new int[registeredDimensions.size()];
+        int x = 0;
+        for (Map.Entry<Integer, DimensionType> ent : registeredDimensions.entrySet())
+        {
+            ret[x++] = ent.getKey();
+        }
+
+        return Arrays.copyOf(ret, x);
+    }
+}

--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -24,6 +24,7 @@ import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.Ev
 
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.event.SurfaceEvent;
 import rtg.api.util.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
@@ -66,7 +67,7 @@ public class EventManagerRTG {
         public void loadChunkRTG(ChunkEvent.Load event) {
 
             // Are we in an RTG world?
-            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG)) {
+            if (!DimensionManagerRTG.isValidDimension(event.getWorld().provider.getDimension())) {
                 return;
             }
 
@@ -83,7 +84,7 @@ public class EventManagerRTG {
         public void generateMinableRTG(OreGenEvent.GenerateMinable event) {
 
             // Are we in an RTG world?
-            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG)) {
+            if (!DimensionManagerRTG.isValidDimension(event.getWorld().provider.getDimension())) {
                 return;
             }
 
@@ -214,7 +215,7 @@ public class EventManagerRTG {
             }
 
             // Are we in an RTG world? Do we have RTG's chunk manager?
-            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG) ||
+            if (!(DimensionManagerRTG.isValidDimension(event.getWorld().provider.getDimension())) ||
                 !(event.getWorld().getBiomeProvider() instanceof BiomeProviderRTG)) {
                 return;
             }
@@ -379,7 +380,7 @@ public class EventManagerRTG {
             }
 
             // Are we in an RTG world? Do we have RTG's chunk manager?
-            if (!(event.getWorld().getWorldType() instanceof WorldTypeRTG) ||
+            if (!(DimensionManagerRTG.isValidDimension(event.getWorld().provider.getDimension())) ||
                 !(event.getWorld().getBiomeProvider() instanceof BiomeProviderRTG)) {
                 return;
             }

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -10,7 +10,10 @@ import net.minecraft.world.gen.ChunkProviderOverworld;
 
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
 import rtg.RTG;
+import rtg.api.RTGAPI;
+import rtg.api.util.Logger;
 import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.gen.ChunkProviderRTG;
 
@@ -36,7 +39,7 @@ public class WorldTypeRTG extends WorldType
     @Override @Nonnull
     public BiomeProvider getBiomeProvider(@Nonnull World world)
     {
-        if (world.provider.getDimension() == 0)
+        if (RTGAPI.config().isValidDimension(world.provider.getDimension()))
         {
             if (biomeProvider == null) {
 
@@ -54,9 +57,9 @@ public class WorldTypeRTG extends WorldType
     @Override @Nonnull
     public IChunkGenerator getChunkGenerator(@Nonnull World world, String generatorOptions)
     {
-        if (world.provider.getDimension() == 0) {
+        if (RTGAPI.config(world.provider.getDimension()).isValidDimension(world.provider.getDimension())) {
 
-            if (chunkProvider == null) {
+            //if (chunkProvider == null) {
                 chunkProvider = new ChunkProviderRTG(world, world.getSeed());
                 RTG.instance.runOnNextServerCloseOnly(clearProvider(chunkProvider));
 
@@ -65,20 +68,21 @@ public class WorldTypeRTG extends WorldType
                 RTG.instance.runOnNextServerCloseOnly(chunkProvider.clearOnServerClose());
 
                 return chunkProvider;
-            }
+            //}
 
             // return a "fake" provider that won't decorate for Streams
-            ChunkProviderRTG result = new ChunkProviderRTG(world, world.getSeed());
-            result.isFakeGenerator();
+            //ChunkProviderRTG result = new ChunkProviderRTG(world, world.getSeed());
+            //result.isFakeGenerator();
 
-            return result;
+            //return result;
 
             // no server close because it's not supposed to decorate
             //return chunkProvider;
         }
-        else return new ChunkProviderOverworld(
-            world, world.getSeed(), world.getWorldInfo().isMapFeaturesEnabled(), generatorOptions
-        );
+        else {
+            Logger.debug("Invalid dimension. Serving up ChunkProviderOverworld instead of ChunkProviderRTG.");
+            return new ChunkProviderOverworld(world, world.getSeed(), world.getWorldInfo().isMapFeaturesEnabled(), generatorOptions);
+        }
     }
 
     @Override

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -46,10 +46,15 @@ public class WorldTypeRTG extends WorldType
                 biomeProvider = new BiomeProviderRTG(world, this);
                 RTG.instance.runOnNextServerCloseOnly(clearProvider(biomeProvider));
             }
+
+            Logger.debug("WorldTypeRTG#getBiomeProvider() returning BiomeProviderRTG");
+
             return biomeProvider;
         }
         else
         {
+            Logger.debug("WorldTypeRTG#getBiomeProvider() returning vanilla BiomeProvider");
+
             return new BiomeProvider(world.getWorldInfo());
         }
     }
@@ -66,6 +71,8 @@ public class WorldTypeRTG extends WorldType
                 // inform the event manager about the ChunkEvent.Load event
                 RTG.eventMgr.setDimensionChunkLoadEvent(world.provider.getDimension(), chunkProvider.delayedDecorator);
                 RTG.instance.runOnNextServerCloseOnly(chunkProvider.clearOnServerClose());
+
+                Logger.debug("WorldTypeRTG#getChunkGenerator() returning ChunkProviderRTG");
 
                 return chunkProvider;
             //}
@@ -92,10 +99,17 @@ public class WorldTypeRTG extends WorldType
     }
 
     private static Runnable clearProvider(Object provider) {
-        if (provider instanceof BiomeProviderRTG)
+        if (provider instanceof BiomeProviderRTG) {
+            Logger.debug("WorldTypeRTG#clearProvider() provider instanceof BiomeProviderRTG (setting to NULL)");
             return () -> biomeProvider = null;
-        else if (provider instanceof ChunkProviderRTG)
+        }
+        else if (provider instanceof ChunkProviderRTG) {
+            Logger.debug("WorldTypeRTG#clearProvider() provider instanceof ChunkProviderRTG (setting to NULL)");
             return () -> chunkProvider = null;
-        else return null;
+        }
+        else {
+            Logger.debug("WorldTypeRTG#clearProvider() returning NULL");
+            return null;
+        }
     }
 }

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import rtg.RTG;
-import rtg.api.RTGAPI;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Logger;
 import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.gen.ChunkProviderRTG;
@@ -39,7 +39,7 @@ public class WorldTypeRTG extends WorldType
     @Override @Nonnull
     public BiomeProvider getBiomeProvider(@Nonnull World world)
     {
-        if (RTGAPI.config().isValidDimension(world.provider.getDimension()))
+        if (DimensionManagerRTG.isValidDimension(world.provider.getDimension()))
         {
             if (biomeProvider == null) {
 
@@ -57,7 +57,7 @@ public class WorldTypeRTG extends WorldType
     @Override @Nonnull
     public IChunkGenerator getChunkGenerator(@Nonnull World world, String generatorOptions)
     {
-        if (RTGAPI.config(world.provider.getDimension()).isValidDimension(world.provider.getDimension())) {
+        if (DimensionManagerRTG.isValidDimension(world.provider.getDimension())) {
 
             //if (chunkProvider == null) {
                 chunkProvider = new ChunkProviderRTG(world, world.getSeed());

--- a/src/main/java/rtg/world/biome/BiomeProviderRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeProviderRTG.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.WorldTypeEvent;
 
 import rtg.api.RTGAPI;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Bayesian;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
@@ -60,7 +61,7 @@ public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
 
         long seed = world.getSeed();
 
-        if (!RTGAPI.config().isValidDimension(world.provider.getDimension())) throw new RuntimeException();
+        if (!DimensionManagerRTG.isValidDimension(world.provider.getDimension())) throw new RuntimeException();
 
         simplex = new OpenSimplexNoise(seed);
         //simplexCell = new SimplexCellularNoise(seed);

--- a/src/main/java/rtg/world/biome/BiomeProviderRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeProviderRTG.java
@@ -59,7 +59,8 @@ public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
         this.smallBendSize *= RTGAPI.config().RIVER_BENDINESS_MULTIPLIER.get();
 
         long seed = world.getSeed();
-        if (world.provider.getDimension() != 0) throw new RuntimeException();
+
+        if (!RTGAPI.config().isValidDimension(world.provider.getDimension())) throw new RuntimeException();
 
         simplex = new OpenSimplexNoise(seed);
         //simplexCell = new SimplexCellularNoise(seed);

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -934,7 +934,10 @@ public class ChunkProviderRTG implements IChunkGenerator
     private void decorateIfOtherwiseSurrounded(IChunkProvider world, ChunkPos pos, Direction fromNewChunk) {
 
         // check if this is the master provider
-        if (WorldTypeRTG.chunkProvider != this) return;
+        if (WorldTypeRTG.chunkProvider != this) {
+            Logger.debug("Cannot decorate-if-otherwise-surrounded.");
+            return;
+        }
 
         // see if otherwise surrounded besides the new chunk
         ChunkPos probe = new ChunkPos(pos.chunkXPos + fromNewChunk.xOffset, pos.chunkZPos + fromNewChunk.zOffset);
@@ -998,7 +1001,10 @@ public class ChunkProviderRTG implements IChunkGenerator
     }
 
     private void clearToDecorateList() {
-        if (WorldTypeRTG.chunkProvider != this) return;
+        if (WorldTypeRTG.chunkProvider != this) {
+            Logger.debug("Cannot clear the to-decorate list.");
+            return;
+        }
         if (populating) return;// in process, do later;
         // we have to make a copy of the set to work on or we'll get errors
         Set<ChunkPos> toProcess = doableLocations(0);

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -38,6 +38,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.*;
 import rtg.api.world.RTGWorld;
 import rtg.util.TimeTracker;
@@ -103,11 +104,21 @@ public class ChunkProviderRTG implements IChunkGenerator
     public final Acceptor<ChunkEvent.Load> delayedDecorator = new Acceptor<ChunkEvent.Load>() {
         @Override
         public void accept(ChunkEvent.Load event) {
-            if (event.isCanceled()) return;
+
+            if (event.isCanceled()) {
+                Logger.debug("CPRTG#Acceptor: event is cancelled.");
+                return;
+            }
+
             ChunkPos pos = event.getChunk().getChunkCoordIntPair();
 
-            if (!toCheck.contains(pos)) return;
+            if (!toCheck.contains(pos)) {
+                Logger.debug("CPRTG#Acceptor: toCheck contains pos.");
+                return;
+            }
+
             toCheck.remove(pos);
+
             for (Direction forPopulation : directions) {
                 decorateIfOtherwiseSurrounded(event.getWorld().getChunkProvider(), pos, forPopulation);
             }
@@ -116,6 +127,9 @@ public class ChunkProviderRTG implements IChunkGenerator
     };
 
     public ChunkProviderRTG(World world, long seed) {
+
+        Logger.debug("STARTED instantiating CPRTG.");
+
         worldObj = world;
         worldUtil = new WorldUtil(world);
         rtgWorld = new RTGWorld(worldObj);
@@ -130,7 +144,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         m.put("distance", "24");
         mapFeaturesEnabled = world.getWorldInfo().isMapFeaturesEnabled();
 
-        boolean isRTGWorld = world.getWorldType() instanceof WorldTypeRTG;
+        boolean isRTGWorld = DimensionManagerRTG.isValidDimension(world.provider.getDimension());
 
         if (isRTGWorld && rtgConfig.ENABLE_CAVE_MODIFICATIONS.get()) {
             caveGenerator = (MapGenCaves) TerrainGen.getModdedMapGen(new MapGenCavesRTG(), EventType.CAVE);
@@ -187,6 +201,8 @@ public class ChunkProviderRTG implements IChunkGenerator
 
         // check for bogus world
         if (worldObj == null) throw new RuntimeException("Attempt to create chunk provider without a world");
+
+        Logger.debug("FINISHED instantiating CPRTG.");
     }
 
     private void setWeightings() {
@@ -670,6 +686,8 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start("Decorations");
         MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Pre(worldObj, rand, new BlockPos(worldX, 0, worldZ)));
 
+        Logger.debug("DecorateBiomeEvent.Pre (%d %d)", worldX, worldZ);
+
         // Ore gen.
         this.generateOres(biome, new BlockPos(worldX, 0, worldZ));
 
@@ -725,6 +743,8 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
 
         MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Post(worldObj, rand, new BlockPos(worldX, 0, worldZ)));
+
+        Logger.debug("DecorateBiomeEvent.Post (%d %d)", worldX, worldZ);
 
         TimeTracker.manager.stop("Decorations");
 
@@ -943,16 +963,32 @@ public class ChunkProviderRTG implements IChunkGenerator
         ChunkPos probe = new ChunkPos(pos.chunkXPos + fromNewChunk.xOffset, pos.chunkZPos + fromNewChunk.zOffset);
 
         // check to see if already decorated; shouldn't be but just in case
-        if (this.alreadyDecorated.contains(probe)) return;
+        if (this.alreadyDecorated.contains(probe)) {
+            Logger.debug("Already decorated (%d %d).", pos.chunkXPos, pos.chunkZPos);
+            return;
+        }
+
         // if an in-process chunk; we'll get a populate call later;
         // if (this.inGeneration.containsKey(probe)) return;
 
         for (Direction checked : directions) {
-            if (checked == compass.opposite(fromNewChunk)) continue; // that's the new chunk
-            if (!chunkExists(true, probe.chunkXPos + checked.xOffset, probe.chunkZPos + checked.zOffset)) return;// that one's missing
+
+            if (checked == compass.opposite(fromNewChunk)) {
+                Logger.debug("Chunk checked (%d %d). Continuing...", pos.chunkXPos, pos.chunkZPos);
+                continue; // that's the new chunk
+            }
+
+            if (!chunkExists(true, probe.chunkXPos + checked.xOffset, probe.chunkZPos + checked.zOffset)) {
+                Logger.debug("Chunk doesn't exist (%d %d). Returning...", pos.chunkXPos, pos.chunkZPos);
+                return;// that one's missing
+            }
         }
+
         // passed all checks
         addToDecorationList(probe);
+
+        Logger.debug("Chunk added to decoration list (%d %d).", probe.chunkXPos, probe.chunkZPos);
+
         //this.doPopulate(probe.chunkXPos, probe.chunkZPos);
     }
 

--- a/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
+++ b/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
@@ -18,8 +18,8 @@ import net.minecraft.world.gen.structure.StructureStart;
 import net.minecraft.world.gen.structure.StructureVillagePieces;
 
 import rtg.api.RTGAPI;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Logger;
-import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 
@@ -74,7 +74,7 @@ public class MapGenVillageRTG extends MapGenVillage
 
         if (i == k && j == l) {
 
-            boolean booRTGWorld = world.getWorldType() instanceof WorldTypeRTG;
+            boolean booRTGWorld = DimensionManagerRTG.isValidDimension(world.provider.getDimension());
             boolean booRTGChunkManager = world.getBiomeProvider() instanceof BiomeProviderRTG;
 
             int worldX = i * 16 + 8;

--- a/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
+++ b/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
@@ -28,8 +28,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import rtg.api.RTGAPI;
+import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Logger;
-import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeProviderRTG;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -122,7 +122,7 @@ public class StructureOceanMonumentRTG extends StructureOceanMonument
     public boolean areBiomesViable(int x, int z, int radius, List<Biome> allowed)
     {
         // Are we in an RTG world?
-        if (!(this.world.getWorldType() instanceof WorldTypeRTG)) {
+        if (!DimensionManagerRTG.isValidDimension(this.world.provider.getDimension())) {
             //Logger.debug("Could not generate ocean monument. This is not an RTG world.");
             return false;
         }


### PR DESCRIPTION
Ok, so this is the proposal for supporting non-Overworld dimensions.

It includes a new API class `DimensionManagerRTG` which holds the list of allowed dimensions and allows mod authors to add their dimensions to the list via the public `addRTGDimension(int dimId)` method. (The Overworld is added to the list during pre-Init.)

All occurrences of `instanceof WorldTypeRTG` checks have been replaced with checks against the list of valid dimensions via `DimensionManagerRTG.isValidDimension(int dimId)`. (The only occurrence that hasn't been replaced is the one in `InitBiomeGensRTG#initBiomeGensRTG` because neither the world nor the dimension is available in that event, but... most alternate dimensions have their own biome layouts, so we can leave this as-is for now. (According to @Zeno410 , if necessary, we could provide an RTG-ifying routine for other mods to call, or they could just omit rivers.)

Finally, there are also a lot of debugging messages included in this because **there's still an issue with biome decoration** that needs to be resolved. I'm pretty sure it's related to the delayed decoration system, but I've been unsuccessful in figuring out exactly what's going on.

Despite this major issue with biome decoration, I propose that we merge this into `1.10.2-dev` because the overall implementation approach is complete, and also so that it's easier for everyone to see what's going so that we can hopefully resolve the biome decoration issue.

@srs-bsns I know you have some concerns on using what are essentially whitelisted dimension ID's, so happy to discuss those here before we merge this.