### PR TITLE
Started Biome Generation Y coord

### DIFF
--- a/src/main/java/rtg/api/config/RTGConfig.java
+++ b/src/main/java/rtg/api/config/RTGConfig.java
@@ -31,7 +31,7 @@ public class RTGConfig extends Config {
     // Base Terrain Height
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    public final ConfigPropertyInt SEA_LEVEL_MODIFIER;
+    public final ConfigPropertyInt BASE_TERRAIN_HEIGHT;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Bedrock
@@ -286,7 +286,7 @@ public class RTGConfig extends Config {
         // Base Terrain Height
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        SEA_LEVEL_MODIFIER = new ConfigPropertyInt(
+        BASE_TERRAIN_HEIGHT = new ConfigPropertyInt(
                 ConfigProperty.Type.INTEGER,
                 "Sea Level Base Height",
                 "Sea Level",

--- a/src/main/java/rtg/api/config/RTGConfig.java
+++ b/src/main/java/rtg/api/config/RTGConfig.java
@@ -28,7 +28,10 @@ public class RTGConfig extends Config {
     public static final IBlockState DEFAULT_VOLCANO_MIX3_BLOCK = Blocks.COAL_BLOCK.getDefaultState();
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Base Terrain Height
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    public final ConfigPropertyInt SEA_LEVEL_MODIFIER;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Bedrock
@@ -37,12 +40,6 @@ public class RTGConfig extends Config {
     public final ConfigPropertyInt FLAT_BEDROCK_LAYERS;
     public final ConfigPropertyString BEDROCK_BLOCK_ID;
     public final ConfigPropertyInt BEDROCK_BLOCK_BYTE;
-
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // SEA LEVEL
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    public final ConfigPropertyInt SEA_LEVEL_MODIFIER;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Biomes
@@ -286,6 +283,18 @@ public class RTGConfig extends Config {
     public RTGConfig() {
 
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // Base Terrain Height
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        SEA_LEVEL_MODIFIER = new ConfigPropertyInt(
+                ConfigProperty.Type.INTEGER,
+                "Sea Level Base Height",
+                "Sea Level",
+                "The 'Y' Level that the World Spawns at.",
+                80, 52, 132
+        );
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Bedrock
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -315,18 +324,6 @@ public class RTGConfig extends Config {
             0, 0, 15
         );
         this.addProperty(BEDROCK_BLOCK_BYTE);
-
-        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        // SEA LEVEL
-        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-        SEA_LEVEL_MODIFIER = new ConfigPropertyInt(
-                ConfigProperty.Type.INTEGER,
-                "Sea Level Base Height",
-                "Sea Level",
-                "The 'Y' Level that the World Spawns at.",
-                80, 32, 132
-                );
 
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Biomes

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
@@ -36,7 +36,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
 
         this.getConfig().addProperty(this.getConfig().ALLOW_WHEAT).set(true);
         this.getConfig().addProperty(this.getConfig().WHEAT_CHANCE).set(50);
-        this.getConfig().addProperty(this.getConfig().WHEAT_MIN_Y).set(RTGAPI.config().SEA_LEVEL_MODIFIER.get());
+        this.getConfig().addProperty(this.getConfig().WHEAT_MIN_Y).set(rtg.api.RTGAPI.config().BASE_TERRAIN_HEIGHT.get());
         this.getConfig().addProperty(this.getConfig().WHEAT_MAX_Y).set(255);
     }
 
@@ -57,7 +57,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         @Override
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
-            return riverized((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 2f + groundEffect.added(rtgWorld, x, y), river);
+            return riverized((rtg.api.RTGAPI.config().BASE_TERRAIN_HEIGHT.get()) + 2f + groundEffect.added(rtgWorld, x, y), river);
 
         }
     }
@@ -136,7 +136,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         DecoShrub decoShrubOak = new DecoShrub();
         decoShrubOak.setLogBlock(Blocks.LOG.getDefaultState());
         decoShrubOak.setLeavesBlock(Blocks.LEAVES.getDefaultState());
-        decoShrubOak.setMaxY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 47);
+        decoShrubOak.setMaxY((rtg.api.RTGAPI.config().BASE_TERRAIN_HEIGHT.get()) + 47);
         decoShrubOak.setLoops(1);
         decoShrubOak.setChance(36);
         this.addDeco(decoShrubOak);
@@ -144,13 +144,13 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         // The occasional flower.
         DecoFlowersRTG decoFlowersRTG = new DecoFlowersRTG();
         decoFlowersRTG.setFlowers(new int[]{0, 2, 3, 4, 5, 6, 7, 8, 9});
-        decoFlowersRTG.setMaxY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 65);
+        decoFlowersRTG.setMaxY((rtg.api.RTGAPI.config().BASE_TERRAIN_HEIGHT.get()) + 65);
         decoFlowersRTG.setStrengthFactor(2f);
         this.addDeco(decoFlowersRTG);
 
         // Lots of grass, but not as much as vanilla.
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMinY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 3);
+        decoGrass.setMinY((rtg.api.RTGAPI.config().BASE_TERRAIN_HEIGHT.get()) + 3);
         decoGrass.setLoops(6);
         this.addDeco(decoGrass);
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
@@ -39,7 +39,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         this.getConfig().addProperty(this.getConfig().WHEAT_MIN_Y).set(RTGAPI.config().SEA_LEVEL_MODIFIER.get());
         this.getConfig().addProperty(this.getConfig().WHEAT_MAX_Y).set(255);
     }
-    //Added Sea LVL Customization Support SDF_Brambe
+
     @Override
     public TerrainBase initTerrain() {
 
@@ -58,7 +58,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 2f + groundEffect.added(rtgWorld, x, y), river);
-            //Added Sea LVL Customization Suppourt SDF_Bramble
+
         }
     }
 
@@ -136,7 +136,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         DecoShrub decoShrubOak = new DecoShrub();
         decoShrubOak.setLogBlock(Blocks.LOG.getDefaultState());
         decoShrubOak.setLeavesBlock(Blocks.LEAVES.getDefaultState());
-        decoShrubOak.setMaxY(110);
+        decoShrubOak.setMaxY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 47);
         decoShrubOak.setLoops(1);
         decoShrubOak.setChance(36);
         this.addDeco(decoShrubOak);
@@ -144,16 +144,16 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         // The occasional flower.
         DecoFlowersRTG decoFlowersRTG = new DecoFlowersRTG();
         decoFlowersRTG.setFlowers(new int[]{0, 2, 3, 4, 5, 6, 7, 8, 9});
-        decoFlowersRTG.setMaxY(128);
+        decoFlowersRTG.setMaxY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 65);
         decoFlowersRTG.setStrengthFactor(2f);
         this.addDeco(decoFlowersRTG);
 
         // Lots of grass, but not as much as vanilla.
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMinY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) - 3);
+        decoGrass.setMinY((RTGAPI.config().SEA_LEVEL_MODIFIER.get()) + 3);
         decoGrass.setLoops(6);
         this.addDeco(decoGrass);
-//Added Sea LVL Customization Support SDF_Bramble
+
         // Very rare fat oak/birch trees.
 
         TreeRTG roburTree1 = new TreeRTGQuercusRobur();


### PR DESCRIPTION
Currently Changed the plains biome to add the y coord it will spawn at. from a config setting.

This is the Plains Biome set to start at y coord lvl 120, since the rest of the biomes are set at 63 the plains biome transitioned downwards to be level with the other biomes stuck at 63 y coord.
![2017-05-29_12 14 32](https://cloud.githubusercontent.com/assets/29005715/26563490/01e1ee02-4490-11e7-8f63-3b6c65ebfc08.png) 

this is the control pitcure where the biome y generation lvl has not been changed.
![2017-05-29_12 18 37](https://cloud.githubusercontent.com/assets/29005715/26563491/01e30328-4490-11e7-992d-b9148189c46c.png)

