### PR TITLE
Decoration Fix

### DIFF
--- a/src/main/java/rtg/api/world/terrain/TerrainBase.java
+++ b/src/main/java/rtg/api/world/terrain/TerrainBase.java
@@ -134,12 +134,12 @@ public abstract class TerrainBase {
 
     public static float getTerrainBase() {
 
-        return (RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f);
+        return (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f);
     }
 
     public static float getTerrainBase(float river) {
 
-        return (RTGAPI.config().SEA_LVL_MODIFIER.get() -1) + 6f * river;
+        return (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() -1) + 6f * river;
     }
 
     public static float mountainCap(float m) {
@@ -156,13 +156,13 @@ public abstract class TerrainBase {
 
     public static float riverized(float height, float river) {
 
-        if (height < 62.45f) {
+        if (height < (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 0.55f)) {
             return height;
         }
         // experimental adjustment to make riverbanks more varied
-        float adjustment = (height - 62.45f)/10f + .6f;
+        float adjustment = (height - (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 0.55f))/10f + .6f;
         river = Bayesian.adjustment(river, adjustment);
-        return 62.45f + (height - 62.45f) * river;
+        return (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 0.55f) + (height - (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 0.55f)) * river;
         }
 
     public static float terrainBeach(int x, int y, OpenSimplexNoise simplex, float river, float pitch1, float pitch2, float baseHeight) {

--- a/src/main/java/rtg/world/biome/BiomeAnalyzer.java
+++ b/src/main/java/rtg/world/biome/BiomeAnalyzer.java
@@ -325,7 +325,7 @@ public class BiomeAnalyzer {
             savedJittered[i] = jitteredBiomes[i];
             //if (savedJittered[i]== null) throw new RuntimeException();
 
-            if (noise[i] > RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5) {
+            if (noise[i] > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5) {
                 // replace
                 jitteredBiomes[i] = realisticBiome;
             } else {
@@ -344,10 +344,10 @@ public class BiomeAnalyzer {
         // put beaches on shores
         beachSearch.notHunted = true;
         beachSearch.absent = false;
-        float beachTop = RTGAPI.config().SEA_LVL_MODIFIER.get() + 1.5f;
+        float beachTop = rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 1.5f;
         for (int i = 0; i < 256; i++) {
             if (beachSearch.absent) break; //no point
-            float beachBottom = RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5f;
+            float beachBottom = rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5f;
             if (noise[i]< beachBottom ||noise[i]>riverAdjusted(beachTop,riverStrength[i])) continue;// this block isn't beach level
             int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
             if (swampBiome[biomeID]) continue;// swamps are acceptable at beach level
@@ -412,7 +412,7 @@ public class BiomeAnalyzer {
         oceanSearch.notHunted = true;
         for (int i = 0; i < 256; i++) {
             if (oceanSearch.absent) break; //no point
-            float oceanTop = RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5f;
+            float oceanTop = (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5f);
             if (noise[i]> oceanTop) continue;// too hight
             int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
             if (oceanBiome[biomeID]) continue;// obviously ocean is OK
@@ -435,7 +435,7 @@ public class BiomeAnalyzer {
         // convert remainder below sea level to lake biome
         for (int i = 0; i < 256; i++) {
             int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
-            if (noise[i]<=RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5&&!riverBiome[biomeID]) {
+            if (noise[i]<=(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1.5f)&&!riverBiome[biomeID]) {
                 // check for river
                 if (!oceanBiome[biomeID] &&
                     !swampBiome[biomeID] &&
@@ -460,8 +460,8 @@ public class BiomeAnalyzer {
     private float riverAdjusted (float top, float river) {
         if (river>=1) return top;
         float erodedRiver = river/RealisticBiomeBase.actualRiverProportion;
-        if (erodedRiver <= 1f) top = top*(1-erodedRiver)+62f*erodedRiver;
-        top = top*(1-river)+62f*river;
+        if (erodedRiver <= 1f) top = top*(1-erodedRiver)+(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1f)*erodedRiver;
+        top = top*(1-river)+(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1f)*river;
         return top;
     }
 }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
@@ -135,8 +135,8 @@ public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase 
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
@@ -140,8 +140,8 @@ public class RealisticBiomeVanillaBirchForestHills extends RealisticBiomeVanilla
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
@@ -100,7 +100,7 @@ public class RealisticBiomeVanillaBirchForestHillsM extends RealisticBiomeVanill
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()- 2) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestM.java
@@ -57,7 +57,7 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
         @Override
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 3f);
         }
     }
 
@@ -135,8 +135,8 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {
@@ -187,16 +187,16 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
         superTallBirch.getDistribution().setNoiseFactor(60f);
         superTallBirch.getDistribution().setNoiseAddend(-15f);
         superTallBirch.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
-        superTallBirch.setMaxY(100);
+        superTallBirch.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         this.addDeco(superTallBirch);
 
         DecoLargeFernDoubleTallgrass decoDoublePlants = new DecoLargeFernDoubleTallgrass();
-        decoDoublePlants.setMaxY(128);
+        decoDoublePlants.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoDoublePlants.setStrengthFactor(8f);
         this.addDeco(decoDoublePlants);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(24f);
         this.addDeco(decoGrass);
 
@@ -210,7 +210,7 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
         this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
 
         DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(110);
+        decoShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         decoShrub.setStrengthFactor(2f);
         this.addDeco(decoShrub);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaHills.java
@@ -140,8 +140,8 @@ public class RealisticBiomeVanillaColdTaigaHills extends RealisticBiomeVanillaBa
                         else if (cliff == 3) {
                             primer.setBlockState(x, k, z, Blocks.SNOW.getDefaultState());
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaM.java
@@ -50,7 +50,7 @@ public class RealisticBiomeVanillaColdTaigaM extends RealisticBiomeVanillaBase {
         @Override
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 80f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 80f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f);
         }
     }
 
@@ -98,7 +98,7 @@ public class RealisticBiomeVanillaColdTaigaM extends RealisticBiomeVanillaBase {
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
@@ -39,7 +39,7 @@ public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase 
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaDesertHills(10f, 80f, 68f, 200f);
+        return new TerrainVanillaDesertHills(10f, 80f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f, 200f);
     }
 
     public class TerrainVanillaDesertHills extends TerrainBase {
@@ -137,8 +137,8 @@ public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase 
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, Blocks.SANDSTONE.getDefaultState());
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
@@ -39,7 +39,7 @@ public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaDesertM(10f, 20f, 68f, 200f);
+        return new TerrainVanillaDesertM(10f, 20f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f, 200f);
     }
 
     public class TerrainVanillaDesertM extends TerrainBase {
@@ -138,8 +138,8 @@ public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowDesertBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
@@ -223,7 +223,7 @@ public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             if (simplex.noise2(i / width, j / width) + simplex.noise2(i / smallW, j / smallW) * smallS > height) {
                                 primer.setBlockState(x, k, z, mixBlockTop);
                                 mix = true;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
@@ -49,7 +49,7 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
     @Override
     public TerrainBase initTerrain() {
 
-       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(125f, 67f, 200f);
+       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(125f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 4f, 200f);
     }
 
     public class TerrainVanillaExtremeHillsEdge extends TerrainBase {
@@ -136,7 +136,7 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             if (simplex.noise2(i / width, j / width) + simplex.noise2(i / smallW, j / smallW) * smallS > height) {
                                 primer.setBlockState(x, k, z, mixBlockTop);
                                 mix = true;
@@ -180,7 +180,7 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
         decoTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
         decoTrees.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         decoTrees.setTreeConditionChance(24);
-        decoTrees.setMaxY(100);
+        decoTrees.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         this.addDeco(decoTrees);
 
         DecoFallenTree decoFallenTree = new DecoFallenTree();
@@ -197,14 +197,14 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
         this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
 
         DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(100);
+        decoShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoShrub.setStrengthFactor(2f);
         this.addDeco(decoShrub);
 
         DecoBoulder decoBoulder = new DecoBoulder();
         decoBoulder.setBoulderBlock(Blocks.MOSSY_COBBLESTONE.getDefaultState());
         decoBoulder.setChance(12);
-        decoBoulder.setMaxY(95);
+        decoBoulder.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 32);
         decoBoulder.setStrengthFactor(2f);
         this.addDeco(decoBoulder);
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
@@ -43,7 +43,7 @@ public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBas
     @Override
     public TerrainBase initTerrain() {
 
-         return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(190f, 67f, 200f);
+         return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(190f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 4f, 200f);
     }
 
     public class TerrainVanillaExtremeHillsM extends TerrainBase {
@@ -129,7 +129,7 @@ public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBas
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             if (simplex.noise2(i / width, j / width) + simplex.noise2(i / smallW, j / smallW) * smallS > height) {
                                 primer.setBlockState(x, k, z, mixBlockTop);
                                 mix = true;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
@@ -47,7 +47,7 @@ public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanilla
     @Override
     public TerrainBase initTerrain() {
 
-       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(150f, 67f, 200f);
+       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(150f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 4f, 200f);
     }
 
     public class TerrainVanillaExtremeHillsPlus extends TerrainBase {
@@ -155,8 +155,8 @@ public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanilla
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
@@ -42,7 +42,7 @@ public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanill
     @Override
     public TerrainBase initTerrain() {
 
-       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(190f, 67f, 200f);
+       return new RealisticBiomeVanillaExtremeHills.RidgedExtremeHills(190f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 4f, 200f);
     }
 
     public class TerrainVanillaExtremeHillsPlusM extends TerrainBase {
@@ -138,8 +138,8 @@ public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanill
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k <  rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k <  rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFlowerForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFlowerForest.java
@@ -136,8 +136,8 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {
@@ -173,7 +173,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
 
         // First, let's get a few shrubs in to break things up a bit.
         DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(110);
+        decoShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         decoShrub.setStrengthFactor(4f);
         decoShrub.setChance(3);
         this.addDeco(decoShrub);
@@ -212,7 +212,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         oakPines.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
         oakPines.setTreeConditionNoise(0f);
         oakPines.setTreeConditionChance(1);
-        oakPines.setMaxY(140);
+        oakPines.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 77);
 
         TreeRTG ponderosaSpruceTree = new TreeRTGPinusPonderosa();
         ponderosaSpruceTree.setLogBlock(BlockUtil.getStateLog(1));
@@ -232,7 +232,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         sprucePines.setTreeCondition(DecoTree.TreeCondition.ALWAYS_GENERATE);
         sprucePines.setTreeConditionNoise(0f);
         sprucePines.setTreeConditionChance(1);
-        sprucePines.setMaxY(140);
+        sprucePines.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 77);
 
         DecoHelper5050 decoPines = new DecoHelper5050(oakPines, sprucePines);
         this.addDeco(decoPines);
@@ -249,7 +249,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         DecoFallenTree decoFallenOak = new DecoFallenTree();
         decoFallenOak.setLogCondition(RANDOM_CHANCE);
         decoFallenOak.setLogConditionChance(8);
-        decoFallenOak.setMaxY(100);
+        decoFallenOak.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoFallenOak.setLogBlock(Blocks.LOG.getDefaultState());
         decoFallenOak.setLeavesBlock(Blocks.LEAVES.getDefaultState());
         decoFallenOak.setMinSize(3);
@@ -257,7 +257,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         DecoFallenTree decoFallenSpruce = new DecoFallenTree();
         decoFallenSpruce.setLogCondition(RANDOM_CHANCE);
         decoFallenSpruce.setLogConditionChance(8);
-        decoFallenSpruce.setMaxY(100);
+        decoFallenSpruce.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoFallenSpruce.setLogBlock(BlockUtil.getStateLog(1));
         decoFallenSpruce.setLeavesBlock(BlockUtil.getStateLeaf(1));
         decoFallenSpruce.setMinSize(3);
@@ -267,7 +267,7 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
 
         // Grass filler.
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(24f);
         this.addDeco(decoGrass);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForest.java
@@ -139,8 +139,8 @@ public class RealisticBiomeVanillaForest extends RealisticBiomeVanillaBase {
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenRiver.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenRiver.java
@@ -79,7 +79,7 @@ public class RealisticBiomeVanillaFrozenRiver extends RealisticBiomeVanillaBase 
                     else if (b != Blocks.WATER) {
                         depth++;
 
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 4f)) {
                             primer.setBlockState(x, k, z, Blocks.GRASS.getDefaultState());
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRiver.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRiver.java
@@ -79,7 +79,7 @@ public class RealisticBiomeVanillaRiver extends RealisticBiomeVanillaBase {
                     else if (b != Blocks.WATER) {
                         depth++;
 
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 3f)) {
                             primer.setBlockState(x, k, z, Blocks.GRASS.getDefaultState());
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
@@ -144,8 +144,8 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {
@@ -181,7 +181,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
 
         DecoMushrooms decoMushrooms = new DecoMushrooms();
         decoMushrooms.setChance(4);
-        decoMushrooms.setMaxY(90);
+        decoMushrooms.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 27);
         decoMushrooms.setRandomType(DecoMushrooms.RandomType.ALWAYS_GENERATE);
         this.addDeco(decoMushrooms);
 
@@ -200,7 +200,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         mangroveTree.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         mangroveTree.setTreeConditionChance(1);
         mangroveTree.setStrengthFactorForLoops(12f);
-        mangroveTree.setMaxY(110);
+        mangroveTree.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         mangroveTree.setScatter(new DecoTree.Scatter(16, 0));
         this.addDeco(mangroveTree);
 
@@ -219,7 +219,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         ceibaPentandraTree.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         ceibaPentandraTree.setTreeConditionChance(1);
         ceibaPentandraTree.setStrengthFactorForLoops(12f);
-        ceibaPentandraTree.setMaxY(110);
+        ceibaPentandraTree.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         ceibaPentandraTree.setScatter(new DecoTree.Scatter(16, 0));
         this.addDeco(ceibaPentandraTree);
 
@@ -238,7 +238,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         ceibaRoseaTree.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         ceibaRoseaTree.setTreeConditionChance(1);
         ceibaRoseaTree.setStrengthFactorForLoops(12f);
-        ceibaRoseaTree.setMaxY(110);
+        ceibaRoseaTree.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         ceibaRoseaTree.setScatter(new DecoTree.Scatter(16, 0));
         this.addDeco(ceibaRoseaTree);
 
@@ -258,13 +258,13 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         DecoShrub darkOakShrub = new DecoShrub();
         darkOakShrub.setLogBlock(BlockUtil.getStateLog2(1));
         darkOakShrub.setLeavesBlock(BlockUtil.getStateLeaf2(1));
-        darkOakShrub.setMaxY(100);
+        darkOakShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         darkOakShrub.setStrengthFactor(8f);
 
         DecoShrub oakShrub = new DecoShrub();
         oakShrub.setLogBlock(Blocks.LOG.getDefaultState());
         oakShrub.setLeavesBlock(Blocks.LEAVES.getDefaultState());
-        oakShrub.setMaxY(100);
+        oakShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         oakShrub.setStrengthFactor(8f);
 
         this.addDeco(new DecoHelperThisOrThat(4, DecoHelperThisOrThat.ChanceType.NOT_EQUALS_ZERO, darkOakShrub, oakShrub));
@@ -272,14 +272,14 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         DecoBoulder decoBoulder = new DecoBoulder();
         decoBoulder.setBoulderBlock(Blocks.MOSSY_COBBLESTONE.getDefaultState());
         decoBoulder.setChance(16);
-        decoBoulder.setMaxY(80);
+        decoBoulder.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 17);
         decoBoulder.setStrengthFactor(2f);
         this.addDeco(decoBoulder);
 
         DecoCobwebs decoCobwebs = new DecoCobwebs();
         decoCobwebs.setChance(1);
-        decoCobwebs.setMinY(63);
-        decoCobwebs.setMaxY(76);
+        decoCobwebs.setMinY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get());
+        decoCobwebs.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 13);
         decoCobwebs.setStrengthFactor(24f);
         decoCobwebs.setAdjacentBlock(BlockUtil.getStateLog2(1));
         decoCobwebs.setMinAdjacents(2);
@@ -287,16 +287,16 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
 
         DecoBaseBiomeDecorations decoBaseBiomeDecorations = new DecoBaseBiomeDecorations();
         decoBaseBiomeDecorations.setNotEqualsZeroChance(2);
-        decoBaseBiomeDecorations.setMaxY(100);
+        decoBaseBiomeDecorations.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         this.addDeco(decoBaseBiomeDecorations);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(100);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoGrass.setStrengthFactor(20f);
         this.addDeco(decoGrass);
 
         DecoDeadBush decoDeadBush = new DecoDeadBush();
-        decoDeadBush.setMaxY(100);
+        decoDeadBush.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoDeadBush.setChance(2);
         decoDeadBush.setStrengthFactor(2f);
         this.addDeco(decoDeadBush);

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForestM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForestM.java
@@ -56,7 +56,7 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         @Override
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 50f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 50f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f);
         }
     }
 
@@ -104,7 +104,7 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {
@@ -122,7 +122,7 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         DecoBoulder decoBoulder = new DecoBoulder();
         decoBoulder.setBoulderBlock(Blocks.MOSSY_COBBLESTONE.getDefaultState());
         decoBoulder.setChance(20);
-        decoBoulder.setMaxY(80);
+        decoBoulder.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 17);
         decoBoulder.setStrengthFactor(2f);
         this.addDeco(decoBoulder);
 
@@ -144,7 +144,7 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         decoTrees.setTreeCondition(DecoTree.TreeCondition.NOISE_GREATER_AND_RANDOM_CHANCE);
         decoTrees.setTreeConditionNoise(0f);
         decoTrees.setTreeConditionChance(1);
-        decoTrees.setMaxY(120);
+        decoTrees.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 57);
         this.addDeco(decoTrees);
 
         DecoFallenTree decoFallenTree = new DecoFallenTree();
@@ -161,30 +161,30 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         this.addDeco(decoFallenTree, this.getConfig().ALLOW_LOGS.get());
 
         DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(110);
+        decoShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         decoShrub.setStrengthFactor(1f);
         this.addDeco(decoShrub);
 
         DecoGrassDoubleTallgrass decoGrassDoubleTallgrass = new DecoGrassDoubleTallgrass();
-        decoGrassDoubleTallgrass.setMaxY(128);
+        decoGrassDoubleTallgrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrassDoubleTallgrass.setStrengthFactor(8f);
         decoGrassDoubleTallgrass.setDoubleGrassChance(6);
         this.addDeco(decoGrassDoubleTallgrass);
 
         DecoDeadBush decoDeadBush = new DecoDeadBush();
-        decoDeadBush.setMaxY(128);
+        decoDeadBush.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoDeadBush.setChance(16);
         decoDeadBush.setStrengthFactor(1f);
         this.addDeco(decoDeadBush);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(4f);
         decoGrass.setChance(2);
         this.addDeco(decoGrass);
 
         DecoGrass decoFern = new DecoGrass(2);
-        decoFern.setMaxY(128);
+        decoFern.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoFern.setStrengthFactor(4f);
         decoFern.setChance(2);
         this.addDeco(decoFern);
@@ -193,7 +193,7 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         this.addDeco(decoBaseBiomeDecorations);
 
         DecoMushrooms decoMushrooms = new DecoMushrooms();
-        decoMushrooms.setMaxY(90);
+        decoMushrooms.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 27);
         decoMushrooms.setRandomType(DecoMushrooms.RandomType.ALWAYS_GENERATE);
         this.addDeco(decoMushrooms);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavanna.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavanna.java
@@ -120,7 +120,7 @@ public class RealisticBiomeVanillaSavanna extends RealisticBiomeVanillaBase {
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             if (simplex.noise2(i / width, j / width) > height) // > 0.27f, i / 12f
                             {
                                 primer.setBlockState(x, k, z, mixBlock);

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaM.java
@@ -56,7 +56,7 @@ public class RealisticBiomeVanillaSavannaM extends RealisticBiomeVanillaBase {
         @Override
         public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 90f, 67f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 90f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 4f);
         }
     }
 
@@ -150,7 +150,7 @@ public class RealisticBiomeVanillaSavannaM extends RealisticBiomeVanillaBase {
                         }
                     }
                     else {
-                        if (k > 74)
+                        if (k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 11)
                         {
                             if (depth == 0) {
                                 if (rand.nextInt(5) == 0) {
@@ -164,8 +164,8 @@ public class RealisticBiomeVanillaSavannaM extends RealisticBiomeVanillaBase {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                         }
-                        else if (depth == 0 && k > 61) {
-                            int r = (int)((k - 62) / 2f);
+                        else if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
+                            int r = (int)((k - rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) / 2f);
                             if(rand.nextInt(r + 2) == 0)
                             {
                                 primer.setBlockState(x, k, z, Blocks.GRASS.getDefaultState());

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateau.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateau.java
@@ -42,7 +42,7 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaSavannaPlateau(true, 35f, 160f, 60f, 40f, 69f);
+        return new TerrainVanillaSavannaPlateau(true, 35f, 160f, 60f, 40f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 6f);
     }
 
     public class TerrainVanillaSavannaPlateau extends TerrainBase {
@@ -158,7 +158,7 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
                     }
                     else {
 
-                        if (k > 74 + grassRaise)
+                        if (k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 11) + grassRaise)
                         {
                             if (depth == 0) {
                                 if (rand.nextInt(5) == 0) {
@@ -172,7 +172,7 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                         }
-                        else if (depth == 0 && k > 61) {
+                        else if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             int r = (int)((k - (62 + grassRaise)) / 2f);
                             if(rand.nextInt(r + 2) == 0)
                             {
@@ -203,20 +203,20 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
 
         DecoBoulder decoBoulder1 = new DecoBoulder();
         decoBoulder1.setBoulderBlock(Blocks.COBBLESTONE.getDefaultState());
-        decoBoulder1.setMaxY(80);
+        decoBoulder1.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 17);
         decoBoulder1.setChance(24);
         this.addDeco(decoBoulder1);
 
         DecoBoulder decoBoulder2 = new DecoBoulder();
         decoBoulder2.setBoulderBlock(Blocks.COBBLESTONE.getDefaultState());
-        decoBoulder1.setMinY(110);
+        decoBoulder1.setMinY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         decoBoulder2.setChance(24);
         this.addDeco(decoBoulder2);
 
         DecoShrub acaciaShrub = new DecoShrub();
         acaciaShrub.setLogBlock(Blocks.LOG2.getDefaultState());
         acaciaShrub.setLeavesBlock(Blocks.LEAVES2.getDefaultState());
-        acaciaShrub.setMaxY(160);
+        acaciaShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         acaciaShrub.setStrengthFactor(3f);
         acaciaShrub.setChance(9);
         this.addDeco(acaciaShrub);
@@ -233,22 +233,22 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
         acaciaTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
         acaciaTrees.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         acaciaTrees.setTreeConditionChance(12);
-        acaciaTrees.setMaxY(160);
+        acaciaTrees.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         this.addDeco(acaciaTrees);
 
         DecoCactus decoCactus = new DecoCactus();
-        decoCactus.setMaxY(160);
+        decoCactus.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         decoCactus.setLoops(60);
         decoCactus.setChance(8);
         this.addDeco(decoCactus, this.getConfig().ALLOW_CACTUS.get());
 
         DecoDoubleGrass decoDoubleGrass = new DecoDoubleGrass();
-        decoDoubleGrass.setMaxY(128);
+        decoDoubleGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoDoubleGrass.setStrengthFactor(3f);
         this.addDeco(decoDoubleGrass);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(10f);
         this.addDeco(decoGrass);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateauM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateauM.java
@@ -42,7 +42,7 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaSavannaPlateauM(true, 35f, 160f, 60f, 40f, 69f);
+        return new TerrainVanillaSavannaPlateauM(true, 35f, 160f, 60f, 40f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 6f);
     }
 
     public class TerrainVanillaSavannaPlateauM extends TerrainBase {
@@ -151,7 +151,7 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
                     }
                     else {
 
-                        if (k > 74 + grassRaise)
+                        if (k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 11) + grassRaise)
                         {
                             if (depth == 0) {
                                 if (rand.nextInt(5) == 0) {
@@ -165,8 +165,8 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                         }
-                        else if (depth == 0 && k > 61) {
-                            int r = (int)((k - (62 + grassRaise)) / 2f);
+                        else if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
+                            int r = (int)((k - ((rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) + grassRaise)) / 2f);
                             if(rand.nextInt(r + 2) == 0)
                             {
                                 primer.setBlockState(x, k, z, Blocks.GRASS.getDefaultState());
@@ -196,20 +196,20 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
 
         DecoBoulder decoBoulder1 = new DecoBoulder();
         decoBoulder1.setBoulderBlock(Blocks.COBBLESTONE.getDefaultState());
-        decoBoulder1.setMaxY(80);
+        decoBoulder1.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 17);
         decoBoulder1.setChance(24);
         this.addDeco(decoBoulder1);
 
         DecoBoulder decoBoulder2 = new DecoBoulder();
         decoBoulder2.setBoulderBlock(Blocks.COBBLESTONE.getDefaultState());
-        decoBoulder1.setMinY(110);
+        decoBoulder1.setMinY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 47);
         decoBoulder2.setChance(24);
         this.addDeco(decoBoulder2);
 
         DecoShrub acaciaShrub = new DecoShrub();
         acaciaShrub.setLogBlock(Blocks.LOG2.getDefaultState());
         acaciaShrub.setLeavesBlock(Blocks.LEAVES2.getDefaultState());
-        acaciaShrub.setMaxY(160);
+        acaciaShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         acaciaShrub.setStrengthFactor(3f);
         acaciaShrub.setChance(9);
         this.addDeco(acaciaShrub);
@@ -226,22 +226,22 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
         acaciaTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
         acaciaTrees.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         acaciaTrees.setTreeConditionChance(12);
-        acaciaTrees.setMaxY(160);
+        acaciaTrees.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         this.addDeco(acaciaTrees);
 
         DecoCactus decoCactus = new DecoCactus();
-        decoCactus.setMaxY(160);
+        decoCactus.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 97);
         decoCactus.setLoops(60);
         decoCactus.setChance(8);
         this.addDeco(decoCactus, this.getConfig().ALLOW_CACTUS.get());
 
         DecoDoubleGrass decoDoubleGrass = new DecoDoubleGrass();
-        decoDoubleGrass.setMaxY(128);
+        decoDoubleGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoDoubleGrass.setStrengthFactor(3f);
         this.addDeco(decoDoubleGrass);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(10f);
         this.addDeco(decoGrass);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
@@ -123,8 +123,8 @@ public class RealisticBiomeVanillaStoneBeach extends RealisticBiomeVanillaBase {
                         else if (cliff == 2) {
                             primer.setBlockState(x, k, z, getShadowStoneBlock(rtgWorld, i, j, x, z, k));
                         }
-                        else if (k < 63) {
-                            if (k < 62) {
+                        else if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()) {
+                            if (k < rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 1) {
                                 primer.setBlockState(x, k, z, fillerBlock);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSunflowerPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSunflowerPlains.java
@@ -97,7 +97,7 @@ public class RealisticBiomeVanillaSunflowerPlains extends RealisticBiomeVanillaB
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwampland.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwampland.java
@@ -87,7 +87,7 @@ public class RealisticBiomeVanillaSwampland extends RealisticBiomeVanillaBase {
                 else if (b == Blocks.STONE) {
                     depth++;
 
-                    if (cliff && k > 64) {
+                    if (cliff && k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 3f)) {
                         if (depth > -1 && depth < 2) {
                             if (rand.nextInt(3) == 0) {
 
@@ -103,7 +103,7 @@ public class RealisticBiomeVanillaSwampland extends RealisticBiomeVanillaBase {
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2f)) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwamplandM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwamplandM.java
@@ -40,7 +40,7 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaSwamplandM(50f, 25f, 60f);
+        return new TerrainVanillaSwamplandM(50f, 25f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get()- 3f);
     }
 
     public class TerrainVanillaSwamplandM extends TerrainBase {
@@ -91,7 +91,7 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
                 else if (b == Blocks.STONE) {
                     depth++;
 
-                    if (cliff && k > 64) {
+                    if (cliff && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 1) {
                         if (depth > -1 && depth < 2) {
                             if (rand.nextInt(3) == 0) {
 
@@ -107,7 +107,7 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
                         }
                     }
                     else {
-                        if (depth == 0 && k > 61) {
+                        if (depth == 0 && k > rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 2) {
                             primer.setBlockState(x, k, z, topBlock);
                         }
                         else if (depth < 4) {
@@ -136,7 +136,7 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
         decoTrees.setTreeType(DecoTree.TreeType.RTG_TREE);
         decoTrees.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         decoTrees.setTreeConditionChance(12);
-        decoTrees.setMaxY(100);
+        decoTrees.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         this.addDeco(decoTrees);
 
         TreeRTG ponderosaTree = new TreeRTGPinusPonderosa();
@@ -153,11 +153,11 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
         deadPineTree.setTreeType(DecoTree.TreeType.RTG_TREE);
         deadPineTree.setTreeCondition(DecoTree.TreeCondition.RANDOM_CHANCE);
         deadPineTree.setTreeConditionChance(18);
-        deadPineTree.setMaxY(100);
+        deadPineTree.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         this.addDeco(deadPineTree);
 
         DecoShrub decoShrub = new DecoShrub();
-        decoShrub.setMaxY(100);
+        decoShrub.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 37);
         decoShrub.setStrengthFactor(3f);
         this.addDeco(decoShrub);
 
@@ -178,13 +178,13 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
         this.addDeco(decoBaseBiomeDecorations);
 
         DecoPumpkin decoPumpkin = new DecoPumpkin();
-        decoPumpkin.setMaxY(90);
+        decoPumpkin.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 27);
         decoPumpkin.setRandomType(DecoPumpkin.RandomType.X_DIVIDED_BY_STRENGTH);
         decoPumpkin.setRandomFloat(50f);
         this.addDeco(decoPumpkin);
 
         DecoGrass decoGrass = new DecoGrass();
-        decoGrass.setMaxY(128);
+        decoGrass.setMaxY(rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 65);
         decoGrass.setStrengthFactor(12f);
         this.addDeco(decoGrass);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaM.java
@@ -42,7 +42,7 @@ public class RealisticBiomeVanillaTaigaM extends RealisticBiomeVanillaBase {
     @Override
     public TerrainBase initTerrain() {
 
-        return new TerrainVanillaTaigaM(70f, 180f, 7f, 100f, 38f, 160f, 68f);
+        return new TerrainVanillaTaigaM(70f, 180f, 7f, 100f, 38f, 160f, rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 5f);
     }
 
     public class TerrainVanillaTaigaM extends TerrainBase {
@@ -113,7 +113,7 @@ public class RealisticBiomeVanillaTaigaM extends RealisticBiomeVanillaBase {
 
                     if (depth == 0) {
 
-                        if (c > 0.45f && c > 1.5f - ((k - 60f) / 65f) + p) {
+                        if (c > 0.45f && c > 1.5f - ((k - rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() - 3f) / rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get() + 3f) + p) {
                             cliff = 1;
                         }
                         if (c > 1.5f) {

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -442,7 +442,7 @@ public class ChunkProviderRTG implements IChunkGenerator
 
                 for (int k = 0; k < 256; k++) {
                     if (k > h) {
-                        if (k < 63) {
+                        if (k < (rtg.api.RTGAPI.config().SEA_LVL_MODIFIER.get())) {
                             primer.setBlockState(i, k, j, Blocks.WATER.getDefaultState());
                         }
                         else {


### PR DESCRIPTION
Changed: Fixed the decoration so it will move up and down with the terrain y coord now.          Fixed water not generating at sea lvl config int., instead it was hard-codded at 63 (default minecraft sea lvl).
Bugs: Minecraft structures spawning in the ground and water. 
![2017-06-04_12 27 53](https://cloud.githubusercontent.com/assets/29005715/26764948/a8cb87e4-492e-11e7-9828-617118e016ef.png)
![2017-06-04_12 54 03](https://cloud.githubusercontent.com/assets/29005715/26764949/a8ceb4a0-492e-11e7-9e7e-e7279c789bf0.png)
TODO: Fix Minecraft Structures Genning in ground and water.

