### PR TITLE
Added LandscapeGenerator to RTGWorld.

### DIFF
--- a/src/main/java/rtg/RTG.java
+++ b/src/main/java/rtg/RTG.java
@@ -1,7 +1,6 @@
 package rtg;
 
 import java.io.File;
-import java.util.ArrayList;
 
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
@@ -70,10 +69,9 @@ import static rtg.api.world.biome.OrganicBiomeGenerator.organicBiomes;
 )
 public class RTG {
 
+    private RTGAPI rtgapi = RTGAPI.getInstance();
     public static WorldTypeRTG worldtype;
     public static EventManagerRTG eventMgr;
-    private ArrayList<Runnable> oneShotServerCloseActions = new ArrayList<>();
-    private ArrayList<Runnable> serverCloseActions = new ArrayList<>();
 
     @Instance(ModInfo.MOD_ID)
     public static RTG instance;
@@ -142,9 +140,9 @@ public class RTG {
     @EventHandler
     public void onServerStopped(FMLServerStoppedEvent event)
     {
-        serverCloseActions.forEach(Runnable::run);
-        oneShotServerCloseActions.forEach(Runnable::run);
-        oneShotServerCloseActions.clear();
+        rtgapi.serverCloseActions.forEach(Runnable::run);
+        rtgapi.oneShotServerCloseActions.forEach(Runnable::run);
+        rtgapi.oneShotServerCloseActions.clear();
     }
 
     private void registerStructures() {
@@ -164,14 +162,6 @@ public class RTG {
         if (RTGAPI.config().ENABLE_STRONGHOLD_MODIFICATIONS.get()) {
             MapGenStructureIO.registerStructure(MapGenStrongholdRTG.Start.class, "rtg_MapGenStrongholdRTG");
         }
-    }
-
-    public void runOnServerClose(Runnable action) {
-        serverCloseActions.add(action);
-    }
-
-    public void runOnNextServerCloseOnly(Runnable action) {
-        serverCloseActions.add(action);
     }
 
     private static void initOrganicBiomes() {

--- a/src/main/java/rtg/api/RTGAPI.java
+++ b/src/main/java/rtg/api/RTGAPI.java
@@ -1,5 +1,7 @@
 package rtg.api;
 
+import java.util.ArrayList;
+
 import rtg.api.config.RTGConfig;
 
 public class RTGAPI {
@@ -9,6 +11,33 @@ public class RTGAPI {
     public static final String VERSION = "1.0.0";
     public static RTGConfig rtgConfig;
     public static String configPath;
+
+    public ArrayList<Runnable> oneShotServerCloseActions;
+    public ArrayList<Runnable> serverCloseActions;
+
+    private static RTGAPI instance = null;
+
+    public static RTGAPI getInstance() {
+
+        if (instance == null) {
+            instance = new RTGAPI();
+        }
+
+        return instance;
+    }
+
+    private RTGAPI() {
+        oneShotServerCloseActions = new ArrayList<>();
+        serverCloseActions = new ArrayList<>();
+    }
+
+    public void runOnServerClose(Runnable action) {
+        this.serverCloseActions.add(action);
+    }
+
+    public void runOnNextServerCloseOnly(Runnable action) {
+        this.serverCloseActions.add(action);
+    }
 
     /*
      * This method is currently unused, but we're leaving it here for when we start

--- a/src/main/java/rtg/api/config/BiomeConfig.java
+++ b/src/main/java/rtg/api/config/BiomeConfig.java
@@ -35,6 +35,9 @@ public class BiomeConfig extends Config {
     public final ConfigPropertyFloat TREE_DENSITY_MULTIPLIER;
     public final ConfigPropertyString TEMPERATURE;
 
+    public final ConfigPropertyBoolean SURFACE_BLEED_IN;
+    public final ConfigPropertyBoolean SURFACE_BLEED_OUT;
+
     /*
      * OPTIONAL CONFIGS
      */
@@ -338,6 +341,22 @@ public class BiomeConfig extends Config {
             ""
         );
         this.addProperty(TEMPERATURE);
+
+        SURFACE_BLEED_IN = this.addProperty(new ConfigPropertyBoolean(
+                Type.BOOLEAN,
+                "Surface Bleed In",
+                "Surface Bleed",
+                "Set to false if other biomes shouldn't bleed into this one",
+                false
+        ));
+
+        SURFACE_BLEED_OUT = this.addProperty(new ConfigPropertyBoolean(
+                Type.BOOLEAN,
+                "Surface Bleed Out",
+                "Surface Bleed",
+                "Set to false if this biome shouldn't bleed into other biomes",
+                false
+        ));
 
         /*
          * OPTIONAL CONFIGS

--- a/src/main/java/rtg/api/config/RTGConfig.java
+++ b/src/main/java/rtg/api/config/RTGConfig.java
@@ -279,6 +279,12 @@ public class RTGConfig extends Config {
     public final ConfigPropertyFloat VOLCANO_CALDERA_MULTIPLIER;
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Surface Bleeding
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    public final ConfigPropertyInt SURFACE_BLEED_RADIUS;
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     public RTGConfig() {
@@ -1424,6 +1430,22 @@ public class RTGConfig extends Config {
         );
         this.addProperty(VOLCANO_CALDERA_MULTIPLIER);
 
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        // Surface Bleeding
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        SURFACE_BLEED_RADIUS = this.addProperty(new ConfigPropertyInt(
+                ConfigProperty.Type.INTEGER,
+                "Surface Bleed Radius",
+                "Surface Bleed",
+                "The maximum distance surfaces will bleed. Set to 0 to disable surface bleeds." +
+                Configuration.NEW_LINE +
+                "Per default surface bleeding is only enabled for beaches. You can control that in biome settings",
+                16, 0, 32
+        ));
+
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     }

--- a/src/main/java/rtg/api/util/TimeTracker.java
+++ b/src/main/java/rtg/api/util/TimeTracker.java
@@ -7,7 +7,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 
-import rtg.RTG;
+import rtg.api.RTGAPI;
 
 /**
  * A simple utility to track time spent in various procedures.
@@ -58,7 +58,7 @@ public class TimeTracker {
     public static class Manager {
         private HashMap<String,TimeTracker> trackers = new HashMap<String,TimeTracker>();
         private Manager() {
-            RTG.instance.runOnServerClose(runReport());
+            RTGAPI.getInstance().runOnServerClose(runReport());
         }
 
         private Runnable runReport() {

--- a/src/main/java/rtg/api/util/TimeTracker.java
+++ b/src/main/java/rtg/api/util/TimeTracker.java
@@ -1,5 +1,5 @@
 
-package rtg.util;
+package rtg.api.util;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/rtg/api/world/RTGWorld.java
+++ b/src/main/java/rtg/api/world/RTGWorld.java
@@ -13,6 +13,7 @@ import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
 import rtg.api.world.biome.OrganicBiomeGenerator;
+import rtg.api.world.gen.LandscapeGenerator;
 
 /**
  * @author topisani
@@ -28,6 +29,7 @@ public class RTGWorld {
     public final TimedHashSet<ChunkPos> decoratedChunks = new TimedHashSet(5000);
     public final BiomeMesa mesaBiome;
     public final OrganicBiomeGenerator organicBiomeGenerator;
+    public final LandscapeGenerator landscapeGenerator;
 
     public RTGWorld(World world) {
         this.world = world;
@@ -40,5 +42,6 @@ public class RTGWorld {
         mesaBiome = (BiomeMesa)Biomes.MESA;
         mesaBiome.generateBands(world.getSeed());
         this.organicBiomeGenerator = new OrganicBiomeGenerator(this);
+        this.landscapeGenerator = new LandscapeGenerator(this);
     }
 }

--- a/src/main/java/rtg/api/world/biome/IBiomeProviderRTG.java
+++ b/src/main/java/rtg/api/world/biome/IBiomeProviderRTG.java
@@ -2,11 +2,9 @@
  * Available under the Lesser GPL License 3.0
  */
 
-package rtg.world.biome;
+package rtg.api.world.biome;
 
 import net.minecraft.world.biome.Biome;
-
-import rtg.world.biome.realistic.RealisticBiomeBase;
 
 /**
  *
@@ -16,6 +14,6 @@ public interface IBiomeProviderRTG {
     int[] getBiomesGens(int x, int z, int par3, int par4);
     float getRiverStrength(int x, int y);
     Biome getBiomeGenAt(int par1, int par2);
-    RealisticBiomeBase getBiomeDataAt(int par1, int par2);
+    IRealisticBiome getBiomeDataAt(int par1, int par2);
     boolean isBorderlessAt(int x, int y);
 }

--- a/src/main/java/rtg/api/world/biome/IRealisticBiome.java
+++ b/src/main/java/rtg/api/world/biome/IRealisticBiome.java
@@ -1,10 +1,12 @@
 package rtg.api.world.biome;
 
 import java.util.ArrayList;
+import java.util.Random;
 
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.SaplingUtil;
@@ -26,6 +28,17 @@ import static rtg.api.RTGAPI.rtgConfig;
 public interface IRealisticBiome {
 
     IRealisticBiome[] arrRealisticBiomes = new IRealisticBiome[256];
+
+    public static IRealisticBiome getRealisticBiome(int id) {
+        return arrRealisticBiomes[id];
+    }
+
+    public static final float actualRiverProportion = 150f/1600f;
+    public static final float riverFlatteningAddend = (actualRiverProportion)/(1f-actualRiverProportion);
+
+    float rNoise(RTGWorld rtgWorld, int x, int y, float border, float river);
+    void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base);
+    void rDecorate(RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks);
 
     Biome baseBiome();
     Biome riverBiome();
@@ -115,6 +128,14 @@ public interface IRealisticBiome {
      */
     default int getExtraGoldGenMaxHeight() {
         return 80;
+    }
+
+    default boolean disallowStoneBeaches() {
+        return false;
+    }
+
+    default boolean disallowAllBeaches() {
+        return false;
     }
 
     String modSlug();

--- a/src/main/java/rtg/api/world/biome/RealisticBiomePatcher.java
+++ b/src/main/java/rtg/api/world/biome/RealisticBiomePatcher.java
@@ -1,4 +1,4 @@
-package rtg.world.biome.realistic;
+package rtg.api.world.biome;
 
 import net.minecraft.world.biome.Biome;
 
@@ -9,7 +9,7 @@ import rtg.api.config.RTGConfig;
 public class RealisticBiomePatcher {
 
     private int patchBiomeId;
-    private RealisticBiomeBase realisticBiome;
+    private IRealisticBiome realisticBiome;
     private Biome baseBiome;
     private RTGConfig rtgConfig = RTGAPI.config();
 
@@ -20,14 +20,14 @@ public class RealisticBiomePatcher {
         if (this.patchBiomeId > -1) {
 
             try {
-                this.realisticBiome = RealisticBiomeBase.getBiome(this.patchBiomeId);
+                this.realisticBiome = IRealisticBiome.getRealisticBiome(this.patchBiomeId);
             }
             catch (Exception e) {
                 throw new RuntimeException("Realistic patch biome " + this.patchBiomeId + " not found. Please make sure this biome is enabled.");
             }
 
             try {
-                this.baseBiome = realisticBiome.baseBiome;
+                this.baseBiome = realisticBiome.baseBiome();
             }
             catch (Exception e) {
                 throw new RuntimeException("Base patch biome " + this.patchBiomeId + " not found. Please make sure this biome is enabled.");
@@ -35,7 +35,7 @@ public class RealisticBiomePatcher {
         }
     }
 
-    public RealisticBiomeBase getPatchedRealisticBiome(String exceptionMessage) {
+    public IRealisticBiome getPatchedRealisticBiome(String exceptionMessage) {
 
         if (this.patchBiomeId < 0) {
             throw new RuntimeException(exceptionMessage);

--- a/src/main/java/rtg/api/world/gen/ChunkLandscape.java
+++ b/src/main/java/rtg/api/world/gen/ChunkLandscape.java
@@ -1,6 +1,6 @@
-package rtg.world.gen;
+package rtg.api.world.gen;
 
-import rtg.world.biome.realistic.RealisticBiomeBase;
+import rtg.api.world.biome.IRealisticBiome;
 
 /**
  *
@@ -8,6 +8,6 @@ import rtg.world.biome.realistic.RealisticBiomeBase;
  */
 public class ChunkLandscape {
     public float [] noise = new float [256];
-    public RealisticBiomeBase [] biome = new RealisticBiomeBase [256];
+    public IRealisticBiome[] biome = new IRealisticBiome [256];
     public float [] river = new float [256];
 }

--- a/src/main/java/rtg/api/world/gen/MesaBiomeCombiner.java
+++ b/src/main/java/rtg/api/world/gen/MesaBiomeCombiner.java
@@ -1,5 +1,5 @@
 
-package rtg.world.gen;
+package rtg.api.world.gen;
 
 import net.minecraft.init.Biomes;
 import net.minecraft.world.biome.Biome;

--- a/src/main/java/rtg/util/UBColumnCache.java
+++ b/src/main/java/rtg/util/UBColumnCache.java
@@ -2,10 +2,9 @@
 package rtg.util;
 
 import exterminatorjeff.undergroundbiomes.api.UBStrataColumn;
-
 import static exterminatorjeff.undergroundbiomes.api.API.STRATA_COLUMN_PROVIDER;
 
-import rtg.RTG;
+import rtg.api.RTGAPI;
 
 
 /**
@@ -18,7 +17,7 @@ public class UBColumnCache {
     private int cachedY = Integer.MIN_VALUE;
 
     public UBColumnCache() {
-        RTG.instance.runOnServerClose(onClose());
+        RTGAPI.getInstance().runOnServerClose(onClose());
     }
 
     public UBStrataColumn column(int x, int y) {

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import rtg.RTG;
+import rtg.api.RTGAPI;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Logger;
 import rtg.world.biome.BiomeProviderRTG;
@@ -44,7 +45,7 @@ public class WorldTypeRTG extends WorldType
             if (biomeProvider == null) {
 
                 biomeProvider = new BiomeProviderRTG(world, this);
-                RTG.instance.runOnNextServerCloseOnly(clearProvider(biomeProvider));
+                RTGAPI.getInstance().runOnNextServerCloseOnly(clearProvider(biomeProvider));
             }
 
             Logger.debug("WorldTypeRTG#getBiomeProvider() returning BiomeProviderRTG");
@@ -66,11 +67,11 @@ public class WorldTypeRTG extends WorldType
 
             //if (chunkProvider == null) {
                 chunkProvider = new ChunkProviderRTG(world, world.getSeed());
-                RTG.instance.runOnNextServerCloseOnly(clearProvider(chunkProvider));
+                RTGAPI.getInstance().runOnNextServerCloseOnly(clearProvider(chunkProvider));
 
                 // inform the event manager about the ChunkEvent.Load event
                 RTG.eventMgr.setDimensionChunkLoadEvent(world.provider.getDimension(), chunkProvider.delayedDecorator);
-                RTG.instance.runOnNextServerCloseOnly(chunkProvider.clearOnServerClose());
+                RTGAPI.getInstance().runOnNextServerCloseOnly(chunkProvider.clearOnServerClose());
 
                 Logger.debug("WorldTypeRTG#getChunkGenerator() returning ChunkProviderRTG");
 

--- a/src/main/java/rtg/world/biome/BiomeProviderRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeProviderRTG.java
@@ -23,8 +23,10 @@ import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
 import rtg.api.world.RTGWorld;
+import rtg.api.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IRealisticBiome;
 import rtg.world.biome.realistic.RealisticBiomeBase;
-import rtg.world.biome.realistic.RealisticBiomePatcher;
+import rtg.api.world.biome.RealisticBiomePatcher;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
@@ -123,14 +125,14 @@ public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
      * @see IBiomeProviderRTG
      */
     @Override
-    public RealisticBiomeBase getBiomeDataAt(int par1, int par2) {
+    public IRealisticBiome getBiomeDataAt(int par1, int par2) {
         /*long coords = ChunkCoordIntPair.chunkXZ2Int(par1, par2);
         if (biomeDataMap.containsKey(coords)) {
             return biomeDataMap.get(coords);
         }*/
-        RealisticBiomeBase output;
+        IRealisticBiome output;
 
-        output = RealisticBiomeBase.getBiome(Biome.getIdForBiome(this.getBiomeGenAt(par1, par2)));
+        output = IRealisticBiome.getRealisticBiome(Biome.getIdForBiome(this.getBiomeGenAt(par1, par2)));
         if (output == null) output = biomePatcher.getPatchedRealisticBiome("No biome " + par1 + " " + par2);
 
         /*if (biomeDataMap.size() > 4096) {
@@ -151,7 +153,7 @@ public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
         int bx, bz;
         for (bx = -2; bx <= 2; bx++) {
             for (bz = -2; bz <= 2; bz++) {
-                borderNoise[Biome.getIdForBiome(getBiomeDataAt(x + bx * 16, z + bz * 16).baseBiome)] += 0.04f;
+                borderNoise[Biome.getIdForBiome(getBiomeDataAt(x + bx * 16, z + bz * 16).baseBiome())] += 0.04f;
             }
         }
 
@@ -188,7 +190,7 @@ public class BiomeProviderRTG extends BiomeProvider implements IBiomeProviderRTG
                 if (biome > 255) throw new RuntimeException(biomeIndexLayer.toString());
                 if (RealisticBiomeBase.getBiome(biome) == null) {
                     f = biomePatcher.getPatchedRealisticBiome("Problem with biome " + biome + " from " +
-                        e.getMessage()).baseBiome.getRainfall() / 65536.0F;
+                        e.getMessage()).baseBiome().getRainfall() / 65536.0F;
                 }
             }
             if (f > 1.0F) f = 1.0F;

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -219,9 +219,6 @@ public abstract class RealisticBiomeBase implements IRealisticBiome {
         return this.erodedNoise(rtgWorld, x, y, river, border, terrainNoise);
     }
 
-    public static final float actualRiverProportion = 150f/1600f;
-    public static final float riverFlatteningAddend = (actualRiverProportion)/(1f-actualRiverProportion);
-
     public float erodedNoise(RTGWorld rtgWorld, int x, int y, float river, float border, float biomeHeight) {
         float r;
         // river of actualRiverProportions now maps to 1; TODO

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
@@ -34,6 +34,8 @@ public class RealisticBiomeVanillaBeach extends RealisticBiomeVanillaBase {
     public void initConfig() {
 
         this.getConfig().ALLOW_VILLAGES.set(false);
+        this.getConfig().SURFACE_BLEED_IN.set(true);
+        this.getConfig().SURFACE_BLEED_OUT.set(true);
         this.getConfig().addProperty(this.getConfig().ALLOW_PALM_TREES).set(true);
     }
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
@@ -29,6 +29,8 @@ public class RealisticBiomeVanillaStoneBeach extends RealisticBiomeVanillaBase {
 
     @Override
     public void initConfig() {
+        this.getConfig().SURFACE_BLEED_IN.set(true);
+        this.getConfig().SURFACE_BLEED_OUT.set(true);
 
         this.getConfig().ALLOW_VILLAGES.set(false);
     }

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -138,7 +138,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         rtgWorld = new RTGWorld(worldObj);
         cmr = (BiomeProviderRTG) worldObj.getBiomeProvider();
         rand = new Random(seed);
-        landscapeGenerator = new LandscapeGenerator(rtgWorld);
+        landscapeGenerator = rtgWorld.landscapeGenerator;
         mapRand = new Random(seed);
         worldSeed = seed;
         volcanoGenerator = new VolcanoGenerator(seed);

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -41,13 +41,16 @@ import rtg.api.config.RTGConfig;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.*;
 import rtg.api.world.RTGWorld;
-import rtg.util.TimeTracker;
+import rtg.api.world.biome.IRealisticBiome;
+import rtg.api.world.gen.ChunkLandscape;
+import rtg.api.world.gen.LandscapeGenerator;
+import rtg.api.util.TimeTracker;
 import rtg.world.WorldTypeRTG;
-import rtg.world.biome.BiomeAnalyzer;
+import rtg.api.world.biome.BiomeAnalyzer;
 import rtg.world.biome.BiomeProviderRTG;
-import rtg.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
-import rtg.world.biome.realistic.RealisticBiomePatcher;
+import rtg.api.world.biome.RealisticBiomePatcher;
 import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
 import rtg.world.gen.structure.MapGenStrongholdRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
@@ -294,10 +297,10 @@ public class ChunkProviderRTG implements IChunkGenerator
         for (k = 0; k < 256; k++) {
 
             try {
-                baseBiomesList[k] = landscape.biome[k].baseBiome;
+                baseBiomesList[k] = landscape.biome[k].baseBiome();
             }
             catch (Exception e) {
-                baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome));
+                baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome()));
             }
         }
         volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise);
@@ -433,7 +436,7 @@ public class ChunkProviderRTG implements IChunkGenerator
     }
 
     private void generateTerrain(IBiomeProviderRTG cmr, int cx, int cz, ChunkPrimer primer,
-                                 RealisticBiomeBase biomes[], float[] noise) {
+                                 IRealisticBiome biomes[], float[] noise) {
 
         int h;
         for (int i = 0; i < 16; i++) {
@@ -457,7 +460,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
     }
 
-    private void replaceBlocksForBiome(int cx, int cz, ChunkPrimer primer, RealisticBiomeBase[]
+    private void replaceBlocksForBiome(int cx, int cz, ChunkPrimer primer, IRealisticBiome[]
         biomes, Biome[] base, float[] n) {
 
         ChunkGeneratorEvent.ReplaceBiomeBlocks event = new ChunkGeneratorEvent.ReplaceBiomeBlocks(
@@ -467,7 +470,7 @@ public class ChunkProviderRTG implements IChunkGenerator
 
         int i, j, depth;
         float river;
-        RealisticBiomeBase biome;
+        IRealisticBiome biome;
 
         for (i = 0; i < 16; i++) {
             for (j = 0; j < 16; j++) {
@@ -480,9 +483,9 @@ public class ChunkProviderRTG implements IChunkGenerator
                 river = -cmr.getRiverStrength(cx * 16 + i, cz * 16 + j);
                 depth = -1;
 
-                if (rtgWorld.organicBiomeGenerator.isOrganicBiome(Biome.getIdForBiome(biome.baseBiome))) {
+                if (rtgWorld.organicBiomeGenerator.isOrganicBiome(Biome.getIdForBiome(biome.baseBiome()))) {
 
-                    rtgWorld.organicBiomeGenerator.organicSurface(cx * 16 + i, cz * 16 + j, primer, biome.baseBiome);
+                    rtgWorld.organicBiomeGenerator.organicSurface(cx * 16 + i, cz * 16 + j, primer, biome.baseBiome());
                 }
                 else {
 
@@ -567,7 +570,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start("Biome Layout");
 
         //Flippy McFlipperson.
-        RealisticBiomeBase biome = cmr.getBiomeDataAt(worldX + 16, worldZ + 16);
+        IRealisticBiome biome = cmr.getBiomeDataAt(worldX + 16, worldZ + 16);
         //Logger.debug("CPRTG#doPopulate: %s at %d %d", biome.baseBiome.getBiomeName(), worldX + 16, worldZ + 16);
 
         TimeTracker.manager.stop("Biome Layout");
@@ -674,7 +677,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
 
         TimeTracker.manager.start("Pools");
-        biome.rDecorator.rPopulatePreDecorate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
+        biome.rDecorator().rPopulatePreDecorate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
         TimeTracker.manager.stop("Pools");
 
         /*
@@ -702,7 +705,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         float river = -cmr.getRiverStrength(worldX + 16, worldZ + 16);
 
         //Border noise. (Does this have to be done here? - Pink)
-        RealisticBiomeBase realisticBiome;
+        IRealisticBiome realisticBiome;
 
         TreeSet<Valued<RealisticBiomeBase>> activeBiomes = new TreeSet();
         for (int bn = 0; bn < 256; bn++) {
@@ -740,7 +743,7 @@ public class ChunkProviderRTG implements IChunkGenerator
 
                     try {
 
-                        realisticBiome.baseBiome.decorate(this.worldObj, rand, new BlockPos(worldX, 0, worldZ));
+                        realisticBiome.baseBiome().decorate(this.worldObj, rand, new BlockPos(worldX, 0, worldZ));
                     }
                     catch (Exception e) {
 
@@ -762,12 +765,12 @@ public class ChunkProviderRTG implements IChunkGenerator
          */
 
         TimeTracker.manager.start("Post-decorations");
-        biome.rDecorator.rPopulatePostDecorate(worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
+        biome.rDecorator().rPopulatePostDecorate(worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
         TimeTracker.manager.stop("Post-decorations");
 
         TimeTracker.manager.start("Entities");
         if (TerrainGen.populate(this, this.worldObj, this.rand, chunkX, chunkZ, hasPlacedVillageBlocks, PopulateChunkEvent.Populate.EventType.ANIMALS)) {
-            WorldEntitySpawner.performWorldGenSpawning(this.worldObj, biome.baseBiome, worldX + 8, worldZ + 8, 16, 16, this.rand);
+            WorldEntitySpawner.performWorldGenSpawning(this.worldObj, biome.baseBiome(), worldX + 8, worldZ + 8, 16, 16, this.rand);
         }
         TimeTracker.manager.stop("Entities");
 
@@ -1067,7 +1070,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
     }
 
-    private void generateOres(RealisticBiomeBase rb, BlockPos pos) {
+    private void generateOres(IRealisticBiome rb, BlockPos pos) {
 
         int x = pos.getX();
         int z = pos.getZ();
@@ -1078,7 +1081,7 @@ public class ChunkProviderRTG implements IChunkGenerator
             return;
         }
 
-        rb.rDecorator.decorateOres(this.worldObj, this.rand, x, z);
+        rb.rDecorator().decorateOres(this.worldObj, this.rand, x, z);
         chunkOreGenTracker.addOreChunk(pos);
     }
 

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -1,8 +1,5 @@
 package rtg.world.gen;
 
-import java.util.*;
-import javax.annotation.Nonnull;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.state.IBlockState;
@@ -25,7 +22,6 @@ import net.minecraft.world.gen.MapGenBase;
 import net.minecraft.world.gen.MapGenCaves;
 import net.minecraft.world.gen.MapGenRavine;
 import net.minecraft.world.gen.structure.*;
-
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
@@ -35,11 +31,11 @@ import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
-
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.*;
+import rtg.api.util.noise.SimplexOctave;
 import rtg.api.world.RTGWorld;
 import rtg.util.TimeTracker;
 import rtg.world.WorldTypeRTG;
@@ -52,6 +48,9 @@ import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
 import rtg.world.gen.structure.MapGenStrongholdRTG;
 import rtg.world.gen.structure.MapGenVillageRTG;
 import rtg.world.gen.structure.StructureOceanMonumentRTG;
+
+import javax.annotation.Nonnull;
+import java.util.*;
 
 
 @SuppressWarnings({"UnusedParameters", "deprecation"})
@@ -307,7 +306,24 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start(replace);
         
         borderNoise = landscapeGenerator.noiseFor(cmr, cx * 16, cz * 16);
-        replaceBlocksForBiome(cx, cz, primer, landscape.biome, baseBiomesList, landscape.noise);
+
+        RealisticBiomeBase[] jitteredBiomes = new RealisticBiomeBase[256];
+
+        RealisticBiomeBase jittered, actual;
+        for (int i = 0; i < 16; i++) {
+            for (int j = 0; j < 16; j++) {
+                rtgWorld.simplex.evaluateNoise(cx * 16 + i, cz * 16 + j, rtgWorld.surfaceJitter);
+                int pX = (int) Math.round(cx * 16 + i + rtgWorld.surfaceJitter.deltax() * rtgConfig.SURFACE_BLEED_RADIUS.get());
+                int pZ = (int) Math.round(cz * 16 + j + rtgWorld.surfaceJitter.deltay() * rtgConfig.SURFACE_BLEED_RADIUS.get());
+                // TODO: These wont work, since they are pre-repair
+                actual = cmr.getBiomeDataAt(cx * 16 + i, cz * 16 + j);
+                jittered = cmr.getBiomeDataAt(pX, pZ);
+                jitteredBiomes[i * 16 + j] = (actual.config.SURFACE_BLEED_IN.get() && jittered.config.SURFACE_BLEED_OUT.get()) ? jittered : actual;
+            }
+        }
+
+        replaceBlocksForBiome(cx, cz, primer, jitteredBiomes, baseBiomesList, landscape.noise);
+
         TimeTracker.manager.stop(replace);
         
         String features = "Vanilla Features";

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -1,20 +1,22 @@
 package rtg.world.gen;
 
 import java.util.Random;
+
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
+
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
 import rtg.api.util.LimitedSet;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.world.biome.IBiomeProviderRTG;
-import rtg.world.biome.realistic.RealisticBiomeBase;
-import static rtg.world.biome.realistic.RealisticBiomeBase.getBiome;
-import rtg.world.biome.realistic.RealisticBiomePatcher;
+import rtg.api.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenVolcano;
+import rtg.api.world.biome.RealisticBiomePatcher;
+import static rtg.world.biome.realistic.RealisticBiomeBase.getBiome;
 
 /**
  *
@@ -73,7 +75,7 @@ public class VolcanoGenerator {
         // Let's go ahead and generate the volcano. Exciting!!! :D
         if (baseX % 4 == 0 && baseY % 4 == 0) {
             int biomeId = Biome.getIdForBiome(cmr.getBiomeGenAt(baseX * 16, baseY * 16));
-            RealisticBiomeBase realisticBiome = getBiome(biomeId);
+            IRealisticBiome realisticBiome = getBiome(biomeId);
 
             // Do we need to patch the biome?
             if (realisticBiome == null) {

--- a/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
+++ b/src/main/java/rtg/world/gen/structure/MapGenVillageRTG.java
@@ -20,8 +20,8 @@ import net.minecraft.world.gen.structure.StructureVillagePieces;
 import rtg.api.RTGAPI;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.Logger;
+import rtg.api.world.biome.IRealisticBiome;
 import rtg.world.biome.BiomeProviderRTG;
-import rtg.world.biome.realistic.RealisticBiomeBase;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class MapGenVillageRTG extends MapGenVillage
@@ -84,11 +84,11 @@ public class MapGenVillageRTG extends MapGenVillage
 
                 BiomeProviderRTG cmr = (BiomeProviderRTG) world.getBiomeProvider();
                 //Why are we flipping XZ here? No idea, but it works. - Pink
-                RealisticBiomeBase realisticBiome = cmr.getBiomeDataAt(worldX, worldZ);
+                IRealisticBiome realisticBiome = cmr.getBiomeDataAt(worldX, worldZ);
 
                 if (realisticBiome.getConfig().ALLOW_VILLAGES.get()) {
                     canSpawnVillage = true;
-                    Logger.debug("Potential village in %s at %d %d", realisticBiome.baseBiome.getBiomeName(), worldX, worldZ);
+                    Logger.debug("Potential village in %s at %d %d", realisticBiome.baseBiome().getBiomeName(), worldX, worldZ);
                 }
             }
             else canSpawnVillage = this.world.getBiomeProvider().areBiomesViable(worldX, worldZ, 0, VILLAGE_SPAWN_BIOMES);


### PR DESCRIPTION
As discussed on Discord, in order to finish off the [1.10.2-surface-bleed](https://github.com/Team-RTG/Realistic-Terrain-Generation/tree/1.10.2-surface-bleed) branch, we need to move `LandscapeGenerator` into `RTGWorld`, so this is the proposal for doing that.

I'm submitting this PR for review since it involves exposing `LandscapeGenerator` to the API, which also involves exposing a few other classes to the API (`BiomeAnalyzer`, `IBiomeProviderRTG`, `RealisticBiomePatcher`, `ChunkLandscape`, `MesaBiomeCombiner`, and `TimeTracker`).

If we think there's too much being exposed, I can try creating some interfaces to minimize exposure, but if no one has any objections, then we can just leave them exposed and merge this into dev so that we can finish off the [1.10.2-surface-bleed](https://github.com/Team-RTG/Realistic-Terrain-Generation/tree/1.10.2-surface-bleed) branch.

The highlights of this PR include:

* `RTG#serverCloseActions` and `RTG#oneShotServerCloseActions` have been moved to `RTGAPI` (which has been refactored as a singleton to avoid static access to these methods).
* `IRealisticBiome` has been enhanced to allow for many occurrences of `RealisticBiomeBase` objects to be replaced with `IRealisticBiome` objects throughout the new API classes. This enhancement includes the addition of the following methods:
  * `float rNoise(RTGWorld rtgWorld, int x, int y, float border, float river);`
  * `void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base);`
  * `void rDecorate(RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks);`