### PR TITLE
LandscapeGenerator accessible from RTGWorld.

### DIFF
--- a/src/main/java/rtg/api/event/SurfaceEvent.java
+++ b/src/main/java/rtg/api/event/SurfaceEvent.java
@@ -5,7 +5,7 @@ import net.minecraft.block.state.IBlockState;
 
 import net.minecraftforge.fml.common.eventhandler.Event;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public class SurfaceEvent extends Event {
 
@@ -15,7 +15,7 @@ public class SurfaceEvent extends Event {
 
     public static class HardcodedBlock extends SurfaceEvent {
 
-        private RTGWorld rtgWorld;
+        private IRTGWorld rtgWorld;
         private int chunkX;
         private int chunkZ;
         private int worldX;
@@ -23,7 +23,7 @@ public class SurfaceEvent extends Event {
         private int worldZ;
         private IBlockState block;
 
-        public HardcodedBlock(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY, IBlockState defaultBlock) {
+        public HardcodedBlock(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY, IBlockState defaultBlock) {
 
             super();
 
@@ -36,7 +36,7 @@ public class SurfaceEvent extends Event {
             this.block = defaultBlock;
         }
 
-        public RTGWorld getRTGWorld() {
+        public IRTGWorld getRTGWorld() {
 
             return rtgWorld;
         }

--- a/src/main/java/rtg/api/world/IRTGWorld.java
+++ b/src/main/java/rtg/api/world/IRTGWorld.java
@@ -10,6 +10,7 @@ import rtg.api.util.TimedHashSet;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.api.world.biome.OrganicBiomeGenerator;
 
 /**
@@ -25,4 +26,5 @@ public interface IRTGWorld {
     TimedHashSet<ChunkPos> decoratedChunks();
     BiomeMesa mesaBiome();
     OrganicBiomeGenerator organicBiomeGenerator();
+    int getBiomeDataAt(IBiomeProviderRTG cmr, int cx, int cz);
 }

--- a/src/main/java/rtg/api/world/IRTGWorld.java
+++ b/src/main/java/rtg/api/world/IRTGWorld.java
@@ -1,0 +1,28 @@
+package rtg.api.world;
+
+import java.util.Random;
+
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeMesa;
+
+import rtg.api.util.TimedHashSet;
+import rtg.api.util.noise.CellNoise;
+import rtg.api.util.noise.OpenSimplexNoise;
+import rtg.api.util.noise.SimplexOctave;
+import rtg.api.world.biome.OrganicBiomeGenerator;
+
+/**
+ * Created by WhichOnesPink on 26/06/2017.
+ */
+public interface IRTGWorld {
+    World world();
+    OpenSimplexNoise simplex();
+    CellNoise cell();
+    CellNoise voronoi();
+    Random rand();
+    SimplexOctave.Disk surfaceJitter();
+    TimedHashSet<ChunkPos> decoratedChunks();
+    BiomeMesa mesaBiome();
+    OrganicBiomeGenerator organicBiomeGenerator();
+}

--- a/src/main/java/rtg/api/world/biome/IBiomeProviderRTG.java
+++ b/src/main/java/rtg/api/world/biome/IBiomeProviderRTG.java
@@ -2,11 +2,9 @@
  * Available under the Lesser GPL License 3.0
  */
 
-package rtg.world.biome;
+package rtg.api.world.biome;
 
 import net.minecraft.world.biome.Biome;
-
-import rtg.world.biome.realistic.RealisticBiomeBase;
 
 /**
  *
@@ -16,6 +14,6 @@ public interface IBiomeProviderRTG {
     int[] getBiomesGens(int x, int z, int par3, int par4);
     float getRiverStrength(int x, int y);
     Biome getBiomeGenAt(int par1, int par2);
-    RealisticBiomeBase getBiomeDataAt(int par1, int par2);
+    IRealisticBiome getBiomeDataAt(int par1, int par2);
     boolean isBorderlessAt(int x, int y);
 }

--- a/src/main/java/rtg/api/world/biome/IRealisticBiome.java
+++ b/src/main/java/rtg/api/world/biome/IRealisticBiome.java
@@ -10,7 +10,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.SaplingUtil;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.VoronoiResult;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.collection.DecoCollectionBase;
@@ -66,20 +66,20 @@ public interface IRealisticBiome {
         return 0; // Lower equals more frequent.
     }
 
-    default float lakePressure(RTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize) {
+    default float lakePressure(IRTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize) {
         if (!this.getConfig().ALLOW_SCENIC_LAKES.get()) return 1f;
         SimplexOctave.Disk jitter = new SimplexOctave.Disk();
-        rtgWorld.simplex.riverJitter().evaluateNoise((float)x / 240.0, (float)y / 240.0, jitter);
+        rtgWorld.simplex().riverJitter().evaluateNoise((float)x / 240.0, (float)y / 240.0, jitter);
         double pX = x + jitter.deltax() * largeBendSize;
         double pY = y + jitter.deltay() * largeBendSize;
-        rtgWorld.simplex.mountain().evaluateNoise((float)x / 80.0, (float)y / 80.0, jitter);
+        rtgWorld.simplex().mountain().evaluateNoise((float)x / 80.0, (float)y / 80.0, jitter);
         pX += jitter.deltax() * mediumBendSize;
         pY += jitter.deltay() * mediumBendSize;
-        rtgWorld.simplex.octave(4).evaluateNoise((float)x / 30.0, (float)y / 30.0, jitter);
+        rtgWorld.simplex().octave(4).evaluateNoise((float)x / 30.0, (float)y / 30.0, jitter);
         pX += jitter.deltax() * smallBendSize;
         pY += jitter.deltay() * smallBendSize;
         //double results =simplexCell.river().noise(pX / lakeInterval, pY / lakeInterval,1.0);
-        VoronoiResult lakeResults = rtgWorld.cell.river().eval((float)pX/ lakeInterval, (float)pY/ lakeInterval);
+        VoronoiResult lakeResults = rtgWorld.cell().river().eval((float)pX/ lakeInterval, (float)pY/ lakeInterval);
         float results = 1f-(float)(lakeResults.interiorValue());
         if (results >1.01) throw new RuntimeException("" + lakeResults.shortestDistance+ " , "+lakeResults.nextDistance);
         if (results<-.01) throw new RuntimeException("" + lakeResults.shortestDistance+ " , "+lakeResults.nextDistance);

--- a/src/main/java/rtg/api/world/biome/IRealisticBiome.java
+++ b/src/main/java/rtg/api/world/biome/IRealisticBiome.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.SaplingUtil;
@@ -65,6 +66,8 @@ public interface IRealisticBiome {
     default int lavaSurfaceLakeChance() {
         return 0; // Lower equals more frequent.
     }
+
+    void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base);
 
     default float lakePressure(IRTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize) {
         if (!this.getConfig().ALLOW_SCENIC_LAKES.get()) return 1f;

--- a/src/main/java/rtg/api/world/biome/OrganicBiomeGenerator.java
+++ b/src/main/java/rtg/api/world/biome/OrganicBiomeGenerator.java
@@ -12,7 +12,7 @@ import net.minecraft.world.gen.NoiseGeneratorPerlin;
 import rtg.api.util.LimitedMap;
 import rtg.api.util.Logger;
 import rtg.api.util.PlaneLocation;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import static rtg.api.util.MathUtils.globalToChunk;
 import static rtg.api.util.MathUtils.globalToLocal;
 
@@ -24,12 +24,12 @@ public class OrganicBiomeGenerator {
     public static boolean[] organicBiomes = new boolean[256];
     private final ChunkProviderOverworld organicProvider;
     private LimitedMap<PlaneLocation.Invariant, int[]> chunkHeights = new LimitedMap<>(64); //Keep the heights for the last 64 chunks around for a bit. We might need them
-    private RTGWorld rtgWorld;
+    private IRTGWorld rtgWorld;
     private NoiseGeneratorPerlin surfaceNoise;
 
-    public OrganicBiomeGenerator(RTGWorld rtgWorld) {
+    public OrganicBiomeGenerator(IRTGWorld rtgWorld) {
         this.rtgWorld = rtgWorld;
-        organicProvider = new ChunkProviderOverworld(rtgWorld.world, rtgWorld.world.getSeed(), rtgWorld.world.getWorldInfo().isMapFeaturesEnabled(), rtgWorld.world.getWorldInfo().getGeneratorOptions());
+        organicProvider = new ChunkProviderOverworld(rtgWorld.world(), rtgWorld.world().getSeed(), rtgWorld.world().getWorldInfo().isMapFeaturesEnabled(), rtgWorld.world().getWorldInfo().getGeneratorOptions());
 
         Field field;
         try {
@@ -91,6 +91,6 @@ public class OrganicBiomeGenerator {
     }
 
     public void organicSurface(int bx, int bz, ChunkPrimer primer, Biome biome) {
-        biome.genTerrainBlocks(rtgWorld.world, rtgWorld.rand, primer, bx, bz, this.surfaceNoise.getValue(bx, bz));
+        biome.genTerrainBlocks(rtgWorld.world(), rtgWorld.rand(), primer, bx, bz, this.surfaceNoise.getValue(bx, bz));
     }
 }

--- a/src/main/java/rtg/api/world/deco/DecoBase.java
+++ b/src/main/java/rtg/api/world/deco/DecoBase.java
@@ -6,7 +6,7 @@ import java.util.Random;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.state.IBlockState;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -46,7 +46,7 @@ public abstract class DecoBase {
     /**
      * Performs pre-generation checks to determine if the deco is allowed to generate.
      */
-    public boolean preGenerate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public boolean preGenerate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.checkRiver) {
 
@@ -62,7 +62,7 @@ public abstract class DecoBase {
      * Generates the decoration.
      * This method should be overridden in the individual deco objects.
      */
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
     }
 

--- a/src/main/java/rtg/api/world/deco/DecoBaseBiomeDecorations.java
+++ b/src/main/java/rtg/api/world/deco/DecoBaseBiomeDecorations.java
@@ -4,7 +4,7 @@ import java.util.Random;
 
 import net.minecraft.util.math.BlockPos;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -53,31 +53,31 @@ public class DecoBaseBiomeDecorations extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
             for (int i = 0; i < loops; i++) {
 
-                int intY = rtgWorld.world.getHeight(new BlockPos(worldX, 0, worldZ)).getY();
+                int intY = rtgWorld.world().getHeight(new BlockPos(worldX, 0, worldZ)).getY();
 
                 if (intY >= this.minY && intY <= this.maxY) {
 
                     if (this.equalsZeroChance > 0) {
 
                         if (rand.nextInt(this.equalsZeroChance) == 0) {
-                            biome.rDecorator().rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
+                            biome.rDecorator().rDecorateSeedBiome(rtgWorld.world(), rand, worldX, worldZ, rtgWorld.simplex(), rtgWorld.cell(), strength, river);
                         }
                     }
                     else if (this.notEqualsZeroChance > 0) {
 
                         if (rand.nextInt(this.notEqualsZeroChance) != 0) {
-                            biome.rDecorator().rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
+                            biome.rDecorator().rDecorateSeedBiome(rtgWorld.world(), rand, worldX, worldZ, rtgWorld.simplex(), rtgWorld.cell(), strength, river);
                         }
                     }
                     else {
 
-                        biome.rDecorator().rDecorateSeedBiome(rtgWorld.world, rand, worldX, worldZ, rtgWorld.simplex, rtgWorld.cell, strength, river);
+                        biome.rDecorator().rDecorateSeedBiome(rtgWorld.world(), rand, worldX, worldZ, rtgWorld.simplex(), rtgWorld.cell(), strength, river);
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoBoulder.java
+++ b/src/main/java/rtg/api/world/deco/DecoBoulder.java
@@ -12,7 +12,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.RandomUtil;
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenBlob;
 
@@ -59,11 +59,11 @@ public class DecoBoulder extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
             WorldGenerator worldGenerator = new WorldGenBlob(boulderBlock, 0, rand, this.water, validGroundBlocks);
 
             for (int l1 = 0; l1 < this.strengthFactor * strength; ++l1) {
@@ -79,11 +79,11 @@ public class DecoBoulder extends DecoBase {
                         break;
 
                     case GET_HEIGHT_VALUE:
-                        k1 = rtgWorld.world.getHeight(new BlockPos(i1, 0, j1)).getY();
+                        k1 = rtgWorld.world().getHeight(new BlockPos(i1, 0, j1)).getY();
                         break;
 
                     default:
-                        k1 = rtgWorld.world.getHeight(new BlockPos(i1, 0, j1)).getY();
+                        k1 = rtgWorld.world().getHeight(new BlockPos(i1, 0, j1)).getY();
                         break;
 
                 }
@@ -97,7 +97,7 @@ public class DecoBoulder extends DecoBase {
                         }
                     }
 
-                    worldGenerator.generate(rtgWorld.world, rand, new BlockPos(i1, k1, j1));
+                    worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(i1, k1, j1));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoCactus.java
+++ b/src/main/java/rtg/api/world/deco/DecoCactus.java
@@ -10,7 +10,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenCacti;
 
@@ -45,11 +45,11 @@ public class DecoCactus extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), CACTUS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), CACTUS)) {
 
                 WorldGenerator worldGenerator = new WorldGenCacti(this.sandOnly, 0, this.soilBlock);
 
@@ -61,7 +61,7 @@ public class DecoCactus extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16);// + 8;
 
                     if (intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoCobwebs.java
+++ b/src/main/java/rtg/api/world/deco/DecoCobwebs.java
@@ -8,7 +8,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.RandomUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenBlock;
 
@@ -43,7 +43,7 @@ public class DecoCobwebs extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
@@ -55,7 +55,7 @@ public class DecoCobwebs extends DecoBase {
                 int k1 = RandomUtil.getRandomInt(rand, this.minY, this.maxY);
 
                 if (rand.nextInt(this.chance) == 0) {
-                    worldGenerator.generate(rtgWorld.world, rand, new BlockPos(i1, k1, j1));
+                    worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(i1, k1, j1));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoCrop.java
+++ b/src/main/java/rtg/api/world/deco/DecoCrop.java
@@ -7,7 +7,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenCrops;
 
@@ -48,11 +48,11 @@ public class DecoCrop extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
             WorldGenerator worldGenerator = new WorldGenCrops(type, size, density, height, water);
 
             if (this.chance < 1) {
@@ -62,7 +62,7 @@ public class DecoCrop extends DecoBase {
             for (int l1 = 0; l1 < this.strengthFactor * strength; ++l1) {
                 int i1 = worldX + rand.nextInt(16);// + 8;
                 int j1 = worldZ + rand.nextInt(16);// + 8;
-                int k1 = rtgWorld.world.getHeight(new BlockPos(i1, 0, j1)).getY();
+                int k1 = rtgWorld.world().getHeight(new BlockPos(i1, 0, j1)).getY();
 
                 if (k1 >= this.minY && k1 <= this.maxY && rand.nextInt(this.chance) == 0) {
 
@@ -73,7 +73,7 @@ public class DecoCrop extends DecoBase {
                         }
                     }
 
-                    worldGenerator.generate(rtgWorld.world, rand, new BlockPos(i1, k1, j1));
+                    worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(i1, k1, j1));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoDeadBush.java
+++ b/src/main/java/rtg/api/world/deco/DecoDeadBush.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -39,11 +39,11 @@ public class DecoDeadBush extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), DEAD_BUSH)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), DEAD_BUSH)) {
 
                 WorldGenerator worldGenerator = new WorldGenDeadBush();
 
@@ -55,7 +55,7 @@ public class DecoDeadBush extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16);// + 8;
 
                     if (intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoDesertWell.java
+++ b/src/main/java/rtg/api/world/deco/DecoDesertWell.java
@@ -6,7 +6,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.feature.WorldGenDesertWells;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -36,7 +36,7 @@ public class DecoDesertWell extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
@@ -51,7 +51,7 @@ public class DecoDesertWell extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16) + 8;
 
                     if (intY <= this.maxY) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoDoubleGrass.java
+++ b/src/main/java/rtg/api/world/deco/DecoDoubleGrass.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenGrass;
 
@@ -38,11 +38,11 @@ public class DecoDoubleGrass extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 WorldGenerator worldGenerator = new WorldGenGrass(Blocks.DOUBLE_PLANT.getStateFromMeta(2), 2);
 
@@ -53,7 +53,7 @@ public class DecoDoubleGrass extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16) + 8;
 
                     if (intY <= this.maxY) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoFallenTree.java
+++ b/src/main/java/rtg/api/world/deco/DecoFallenTree.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.DecoUtil;
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenLog;
 
@@ -71,12 +71,12 @@ public class DecoFallenTree extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            float noise = rtgWorld.simplex.noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            float noise = rtgWorld.simplex().noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
 
             //Do we want to choose a random log?
             if (this.randomLogBlocks.length > 0) {
@@ -105,7 +105,7 @@ public class DecoFallenTree extends DecoBase {
                 if (isValidLogCondition(noise, strength, rand)) {
                     int x22 = worldX + rand.nextInt(16);// + 8;
                     int z22 = worldZ + rand.nextInt(16);// + 8;
-                    int y22 = rtgWorld.world.getHeight(new BlockPos(x22, 0, z22)).getY();
+                    int y22 = rtgWorld.world().getHeight(new BlockPos(x22, 0, z22)).getY();
 
                     if (y22 <= this.maxY) {
 
@@ -116,7 +116,7 @@ public class DecoFallenTree extends DecoBase {
                             }
                         }
 
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(x22, y22, z22));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(x22, y22, z22));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoFlowersRTG.java
+++ b/src/main/java/rtg/api/world/deco/DecoFlowersRTG.java
@@ -9,7 +9,7 @@ import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS;
 
 import rtg.api.util.RandomUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenFlowersRTG;
 
@@ -67,11 +67,11 @@ public class DecoFlowersRTG extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), FLOWERS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), FLOWERS)) {
 
                 WorldGenerator worldGenerator = new WorldGenFlowersRTG(this.flowers);
 
@@ -88,7 +88,7 @@ public class DecoFlowersRTG extends DecoBase {
                             break;
 
                         case GET_HEIGHT_VALUE:
-                            intY = rtgWorld.world.getHeight(new BlockPos(intX, 0, intZ)).getY();
+                            intY = rtgWorld.world().getHeight(new BlockPos(intX, 0, intZ)).getY();
                             break;
 
                         default:
@@ -101,14 +101,14 @@ public class DecoFlowersRTG extends DecoBase {
 
                         if (rand.nextInt(this.notEqualsZeroChance) != 0) {
 
-                            worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                            worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                         }
                     }
                     else {
 
                         if (rand.nextInt(this.chance) == 0) {
 
-                            worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                            worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                         }
                     }
                 }

--- a/src/main/java/rtg/api/world/deco/DecoForgeEvent.java
+++ b/src/main/java/rtg/api/world/deco/DecoForgeEvent.java
@@ -7,7 +7,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -40,11 +40,11 @@ public class DecoForgeEvent extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), this.event)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), this.event)) {
                 ;
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoGrass.java
+++ b/src/main/java/rtg/api/world/deco/DecoGrass.java
@@ -9,7 +9,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenGrass;
 
@@ -84,11 +84,11 @@ public class DecoGrass extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 this.setLoops((this.strengthFactor > 0f) ? (int) (this.strengthFactor * strength) : this.loops);
                 this.setLoops((this.loops > this.MAX_LOOPS) ? this.MAX_LOOPS : this.loops);
@@ -107,13 +107,13 @@ public class DecoGrass extends DecoBase {
                     if (this.notEqualsZeroChance > 1) {
 
                         if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.notEqualsZeroChance) != 0) {
-                            grassGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                            grassGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                         }
                     }
                     else {
 
                         if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-                            grassGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                            grassGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                         }
                     }
                 }

--- a/src/main/java/rtg/api/world/deco/DecoGrassDoubleTallgrass.java
+++ b/src/main/java/rtg/api/world/deco/DecoGrassDoubleTallgrass.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenGrass;
 
@@ -42,11 +42,11 @@ public class DecoGrassDoubleTallgrass extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 WorldGenerator worldGenerator = null;
                 if (this.doubleGrassChance > 0) {
@@ -91,7 +91,7 @@ public class DecoGrassDoubleTallgrass extends DecoBase {
 
                     if (intY <= this.maxY) {
 
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoJungleCacti.java
+++ b/src/main/java/rtg/api/world/deco/DecoJungleCacti.java
@@ -8,7 +8,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenJungleCacti;
 
@@ -41,11 +41,11 @@ public class DecoJungleCacti extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), CACTUS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), CACTUS)) {
 
                 WorldGenerator worldGenerator = new WorldGenJungleCacti(this.sandOnly, rand.nextInt(this.extraHeight), this.sandMeta);
 
@@ -55,7 +55,7 @@ public class DecoJungleCacti extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16);// + 8;
 
                     if (intY < this.maxY) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoJungleGrassVines.java
+++ b/src/main/java/rtg/api/world/deco/DecoJungleGrassVines.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenGrass;
 import rtg.api.world.gen.feature.WorldGenVinesRTG;
@@ -42,11 +42,11 @@ public class DecoJungleGrassVines extends DecoBase {
      * No config options for this one yet. Just ripped it directly from the old code.
      */
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 for (int l14 = 0; l14 < 16f * strength; l14++) {
                     int l19 = worldX + rand.nextInt(16);// + 8;
@@ -55,15 +55,15 @@ public class DecoJungleGrassVines extends DecoBase {
 
                     if (rand.nextInt(8) == 0) {
                         if (rand.nextBoolean()) {
-                            this.worldgeneratorGrass.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorGrass.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                         else {
-                            this.worldgeneratorFern.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorFern.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                     }
 
                     for (int h44 = 0; h44 < 4 && k22 > 63; h44++) {
-                        worldgeneratorVines.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                        worldgeneratorVines.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                     }
                 }
 
@@ -74,10 +74,10 @@ public class DecoJungleGrassVines extends DecoBase {
 
                     if (rand.nextInt(5) == 0) {
                         if (rand.nextBoolean()) {
-                            this.worldgeneratorDoubleTallgrass.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorDoubleTallgrass.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                         else {
-                            this.worldgeneratorLargeFern.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorLargeFern.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                     }
                 }
@@ -89,17 +89,17 @@ public class DecoJungleGrassVines extends DecoBase {
 
                     if (rand.nextInt(8) == 0) {
                         if (rand.nextBoolean()) {
-                            this.worldgeneratorGrass.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorGrass.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                         else {
-                            this.worldgeneratorFern.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            this.worldgeneratorFern.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                     }
 
                     if (k22 > 63) {
 
                         for (int h44 = 0; h44 < 8; h44++) {
-                            worldgeneratorVines.generate(rtgWorld.world, rand, new BlockPos(l19, k22, j24));
+                            worldgeneratorVines.generate(rtgWorld.world(), rand, new BlockPos(l19, k22, j24));
                         }
                     }
                 }

--- a/src/main/java/rtg/api/world/deco/DecoJungleLilypadVines.java
+++ b/src/main/java/rtg/api/world/deco/DecoJungleLilypadVines.java
@@ -10,7 +10,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenVinesRTG;
 
@@ -30,11 +30,11 @@ public class DecoJungleLilypadVines extends DecoBase {
      * No config options for this one yet. Just ripped it directly from the old code.
      */
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), LILYPAD)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), LILYPAD)) {
 
                 WorldGenerator worldgeneratorLilypads = new WorldGenWaterlily();
                 WorldGenerator worldgeneratorVines = new WorldGenVinesRTG();
@@ -43,18 +43,18 @@ public class DecoJungleLilypadVines extends DecoBase {
                 for (int b33 = 0; b33 < 5; b33++) {
                     int j6 = worldX + rand.nextInt(16) + 8;
                     int k10 = worldZ + rand.nextInt(16) + 8;
-                    int z52 = rtgWorld.world.getHeight(new BlockPos(j6, 0, k10)).getY();
+                    int z52 = rtgWorld.world().getHeight(new BlockPos(j6, 0, k10)).getY();
 
                     for (int h44 = 0; h44 < 8; h44++) {
 
                         if (z52 > 64) {
-                            worldgeneratorLilypads.generate(rtgWorld.world, rand, new BlockPos(j6, z52, k10));
+                            worldgeneratorLilypads.generate(rtgWorld.world(), rand, new BlockPos(j6, z52, k10));
                         }
                     }
 
                     for (int h44 = 100; h44 > 0; h44--) {
 
-                        worldgeneratorVines.generate(rtgWorld.world, rand, new BlockPos(j6, z52, k10));
+                        worldgeneratorVines.generate(rtgWorld.world(), rand, new BlockPos(j6, z52, k10));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoLargeFernDoubleTallgrass.java
+++ b/src/main/java/rtg/api/world/deco/DecoLargeFernDoubleTallgrass.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenGrass;
 
@@ -45,11 +45,11 @@ public class DecoLargeFernDoubleTallgrass extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 WorldGenerator worldgeneratorDoubleTallgrass = new WorldGenGrass(Blocks.DOUBLE_PLANT.getStateFromMeta(GRASS_META), GRASS_META);
                 WorldGenerator worldgeneratorLargeFern = new WorldGenGrass(Blocks.DOUBLE_PLANT.getStateFromMeta(FERN_META), FERN_META);
@@ -66,33 +66,33 @@ public class DecoLargeFernDoubleTallgrass extends DecoBase {
 
                             if (rand.nextInt(this.fernChance) == 0) {
 
-                                worldgeneratorLargeFern.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorLargeFern.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                             else {
 
-                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                         }
                         else if (this.grassChance > 0) {
 
                             if (rand.nextInt(this.grassChance) == 0) {
 
-                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                             else {
 
-                                worldgeneratorLargeFern.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorLargeFern.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                         }
                         else {
 
                             if (rand.nextBoolean()) {
 
-                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorDoubleTallgrass.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                             else {
 
-                                worldgeneratorLargeFern.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgeneratorLargeFern.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                         }
                     }

--- a/src/main/java/rtg/api/world/deco/DecoLayer.java
+++ b/src/main/java/rtg/api/world/deco/DecoLayer.java
@@ -10,7 +10,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenLayers;
 
@@ -56,11 +56,11 @@ public class DecoLayer extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
             WorldGenerator worldGenerator = new WorldGenLayers(this.layerBlock, this.layerProperty, this.dropHeight, this.layerRange, this.layerScatter);
 
             int loopCount = this.loops;
@@ -68,18 +68,18 @@ public class DecoLayer extends DecoBase {
             for (int i = 0; i < loopCount; i++) {
                 int intX = worldX + rand.nextInt(16);// + 8;
                 int intZ = worldZ + rand.nextInt(16);// + 8;
-                int intY = rtgWorld.world.getHeight(new BlockPos(intX, 0, intZ)).getY();
+                int intY = rtgWorld.world().getHeight(new BlockPos(intX, 0, intZ)).getY();
 
                 if (this.notEqualsZeroChance > 1) {
 
                     if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.notEqualsZeroChance) != 0) {
-                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
+                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world(), rand, intX, intY, intZ, hasPlacedVillageBlocks);
                     }
                 }
                 else {
 
                     if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
+                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world(), rand, intX, intY, intZ, hasPlacedVillageBlocks);
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoMushrooms.java
+++ b/src/main/java/rtg/api/world/deco/DecoMushrooms.java
@@ -10,7 +10,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -44,11 +44,11 @@ public class DecoMushrooms extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), SHROOM)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), SHROOM)) {
 
                 // Let's figure out what the rand.nextInt() argument should be.
                 switch (this.randomType) {
@@ -81,10 +81,10 @@ public class DecoMushrooms extends DecoBase {
                         if (intY <= this.maxY) {
 
                             if (rand.nextBoolean()) {
-                                worldGeneratorBrownShrooms.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldGeneratorBrownShrooms.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                             else {
-                                worldGeneratorRedShrooms.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldGeneratorRedShrooms.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                             }
                         }
                     }

--- a/src/main/java/rtg/api/world/deco/DecoPond.java
+++ b/src/main/java/rtg/api/world/deco/DecoPond.java
@@ -8,7 +8,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenPond;
 
@@ -26,7 +26,7 @@ public class DecoPond extends DecoBase {
     private RTGConfig rtgConfig = RTGAPI.config();
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed && rtgConfig.WATER_SURFACE_LAKE_CHANCE.get() > 0 && biome.getConfig().ALLOW_PONDS_WATER.get()) {
 
@@ -35,13 +35,13 @@ public class DecoPond extends DecoBase {
 
                 int i2 = worldX + rand.nextInt(16);// + 8;
                 int i8 = worldZ + rand.nextInt(16);// + 8;
-                int l4 = rtgWorld.world.getHeight(new BlockPos(i2, 0, i8)).getY();
+                int l4 = rtgWorld.world().getHeight(new BlockPos(i2, 0, i8)).getY();
 
                 if (rand.nextInt(this.chunksPerPond) == 0) {
 
                     if (l4 >= this.minY && l4 <= this.maxY) {
 
-                        pondGenerator.generate(rtgWorld.world, rand, new BlockPos(i2, l4, i8));
+                        pondGenerator.generate(rtgWorld.world(), rand, new BlockPos(i2, l4, i8));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoPumpkin.java
+++ b/src/main/java/rtg/api/world/deco/DecoPumpkin.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -43,11 +43,11 @@ public class DecoPumpkin extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), PUMPKIN)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), PUMPKIN)) {
 
                 // Let's figure out what the rand.nextInt() argument should be.
                 switch (this.randomType) {
@@ -77,7 +77,7 @@ public class DecoPumpkin extends DecoBase {
                         int intZ = worldZ + rand.nextInt(16) + 8;
 
                         if (intY <= this.maxY) {
-                            worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                            worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                         }
                     }
                 }

--- a/src/main/java/rtg/api/world/deco/DecoReed.java
+++ b/src/main/java/rtg/api/world/deco/DecoReed.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -37,11 +37,11 @@ public class DecoReed extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), REED)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), REED)) {
 
                 WorldGenerator worldGenerator = new WorldGenReed();
 
@@ -52,7 +52,7 @@ public class DecoReed extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16) + 8;
 
                     if (intY <= this.maxY) {
-                        worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                        worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoSeaweed.java
+++ b/src/main/java/rtg/api/world/deco/DecoSeaweed.java
@@ -8,7 +8,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.BlockUtil;
 import rtg.api.util.RandomUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenSeaweed;
 
@@ -68,7 +68,7 @@ public class DecoSeaweed extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
@@ -77,7 +77,7 @@ public class DecoSeaweed extends DecoBase {
              * The actual amount of seaweed that ends up being generated could be *less* than this value,
              * depending on environmental conditions.
              */
-            float noise = rtgWorld.simplex.noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
+            float noise = rtgWorld.simplex().noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
             int loopCount = this.loops;
             loopCount = (this.strengthFactorForLoops > 0f) ? (int) (this.strengthFactorForLoops * strength) : loopCount;
             loopCount = (this.strengthNoiseFactorForLoops) ? (int) (noise * strength) : loopCount;
@@ -99,7 +99,7 @@ public class DecoSeaweed extends DecoBase {
 
                 if (intY <= this.maxY && intY >= this.minY && isValidCondition(noise, rand, strength)) {
 
-                    worldGen.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                    worldGen.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoShrub.java
+++ b/src/main/java/rtg/api/world/deco/DecoShrub.java
@@ -10,7 +10,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.BlockUtil;
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenShrubRTG;
 
@@ -69,7 +69,7 @@ public class DecoShrub extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
@@ -91,7 +91,7 @@ public class DecoShrub extends DecoBase {
                 this.setLeavesBlock(this.randomLeavesBlocks[rnd]);
             }
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
             WorldGenerator worldGenerator = new WorldGenShrubRTG(this.size, this.logBlock, this.leavesBlock, this.sand);
 
             int loopCount = this.loops;
@@ -99,18 +99,18 @@ public class DecoShrub extends DecoBase {
             for (int i = 0; i < loopCount; i++) {
                 int intX = worldX + rand.nextInt(16);// + 8;
                 int intZ = worldZ + rand.nextInt(16);// + 8;
-                int intY = rtgWorld.world.getHeight(new BlockPos(intX, 0, intZ)).getY();
+                int intY = rtgWorld.world().getHeight(new BlockPos(intX, 0, intZ)).getY();
 
                 if (this.notEqualsZeroChance > 1) {
 
                     if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.notEqualsZeroChance) != 0) {
-                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
+                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world(), rand, intX, intY, intZ, hasPlacedVillageBlocks);
                     }
                 }
                 else {
 
                     if (intY >= this.minY && intY <= this.maxY && rand.nextInt(this.chance) == 0) {
-                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world, rand, intX, intY, intZ, hasPlacedVillageBlocks);
+                        generateWorldGenerator(worldGenerator, worldUtil, rtgWorld.world(), rand, intX, intY, intZ, hasPlacedVillageBlocks);
                     }
                 }
             }

--- a/src/main/java/rtg/api/world/deco/DecoSingleBiomeDecorations.java
+++ b/src/main/java/rtg/api/world/deco/DecoSingleBiomeDecorations.java
@@ -5,7 +5,7 @@ import java.util.Random;
 
 import net.minecraft.util.math.ChunkPos;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 
 /**
@@ -15,12 +15,12 @@ import rtg.api.world.biome.IRealisticBiome;
 public class DecoSingleBiomeDecorations extends DecoBaseBiomeDecorations {
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
         if (this.allowed) {
             // skip if already decorated
             ChunkPos position = new ChunkPos(worldX,worldZ);
-            if (rtgWorld.decoratedChunks.contains(position)) return;
-            rtgWorld.decoratedChunks.add(position);
+            if (rtgWorld.decoratedChunks().contains(position)) return;
+            rtgWorld.decoratedChunks().add(position);
             super.generate(biome, rtgWorld, rand, worldX, worldZ, strength, river, hasPlacedVillageBlocks); 
         }
     }

--- a/src/main/java/rtg/api/world/deco/DecoSponge.java
+++ b/src/main/java/rtg/api/world/deco/DecoSponge.java
@@ -13,7 +13,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 
 import rtg.api.util.RandomUtil;
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenSponge;
 
@@ -60,11 +60,11 @@ public class DecoSponge extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+            WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
             WorldGenerator worldGenerator = new WorldGenSponge(spongeBlock, 0, rand, validGroundBlocks);
 
             for (int l1 = 0; l1 < this.strengthFactor * strength; ++l1) {
@@ -80,17 +80,17 @@ public class DecoSponge extends DecoBase {
                         break;
 
                     case GET_HEIGHT_VALUE:
-                        k1 = rtgWorld.world.getHeight(new BlockPos(i1, 0, j1)).getY();
+                        k1 = rtgWorld.world().getHeight(new BlockPos(i1, 0, j1)).getY();
                         break;
 
                     default:
-                        k1 = rtgWorld.world.getHeight(new BlockPos(i1, 0, j1)).getY();
+                        k1 = rtgWorld.world().getHeight(new BlockPos(i1, 0, j1)).getY();
                         break;
 
                 }
 
                 if (k1 >= this.minY && k1 <= this.maxY && rand.nextInt(this.chance) == 0) {
-                    worldGenerator.generate(rtgWorld.world, rand, new BlockPos(i1, k1, j1));
+                    worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(i1, k1, j1));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/DecoTree.java
+++ b/src/main/java/rtg/api/world/deco/DecoTree.java
@@ -15,7 +15,7 @@ import rtg.api.event.DecorateBiomeEventRTG;
 import rtg.api.util.DecoUtil;
 import rtg.api.util.RandomUtil;
 import rtg.api.util.WorldUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 
@@ -147,7 +147,7 @@ public class DecoTree extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
@@ -156,7 +156,7 @@ public class DecoTree extends DecoBase {
              * The actual number of trees that end up being generated could be *less* than this value,
              * depending on environmental conditions.
              */
-            float noise = rtgWorld.simplex.noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
+            float noise = rtgWorld.simplex().noise2(worldX / this.distribution.noiseDivisor, worldZ / this.distribution.noiseDivisor) * this.distribution.noiseFactor + this.distribution.noiseAddend;
             int loopCount = this.loops;
             loopCount = (this.strengthFactorForLoops > 0f) ? (int) (this.strengthFactorForLoops * strength) : loopCount;
             loopCount = (this.strengthNoiseFactorForLoops) ? (int) (noise * strength) : loopCount;
@@ -185,7 +185,7 @@ public class DecoTree extends DecoBase {
              * the additional context.
              */
             DecorateBiomeEventRTG.DecorateRTG event = new DecorateBiomeEventRTG.DecorateRTG(
-                rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), TREE, loopCount
+                rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), TREE, loopCount
             );
             MinecraftForge.TERRAIN_GEN_BUS.post(event);
 
@@ -197,14 +197,14 @@ public class DecoTree extends DecoBase {
                     return;
                 }
 
-                WorldUtil worldUtil = new WorldUtil(rtgWorld.world);
+                WorldUtil worldUtil = new WorldUtil(rtgWorld.world());
                 DecoBase.tweakTreeLeaves(this, false, true);
 
                 for (int i = 0; i < loopCount; i++) {
 
                     int intX = scatter.get(rand, worldX); // + 8;
                     int intZ = scatter.get(rand, worldZ); // + 8;
-                    int intY = rtgWorld.world.getHeight(new BlockPos(intX, 0, intZ)).getY();
+                    int intY = rtgWorld.world().getHeight(new BlockPos(intX, 0, intZ)).getY();
 
                     //Logger.info("noise = %f", noise);
 
@@ -228,14 +228,14 @@ public class DecoTree extends DecoBase {
                                 this.tree.setTrunkSize(RandomUtil.getRandomInt(rand, this.minTrunkSize, this.maxTrunkSize));
                                 this.tree.setCrownSize(RandomUtil.getRandomInt(rand, this.minCrownSize, this.maxCrownSize));
                                 this.tree.setNoLeaves(this.noLeaves);
-                                this.tree.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                this.tree.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
 
                                 break;
 
                             case WORLDGEN:
 
                                 WorldGenerator worldgenerator = this.worldGen;
-                                worldgenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                                worldgenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
 
                                 break;
 

--- a/src/main/java/rtg/api/world/deco/DecoVines.java
+++ b/src/main/java/rtg/api/world/deco/DecoVines.java
@@ -13,7 +13,7 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.gen.feature.WorldGenVinesRTG;
 
@@ -69,11 +69,11 @@ public class DecoVines extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 
-            if (TerrainGen.decorate(rtgWorld.world, rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
+            if (TerrainGen.decorate(rtgWorld.world(), rand, new BlockPos(worldX, 0, worldZ), GRASS)) {
 
                 this.worldGenerator = new WorldGenVinesRTG(this.vineBlock, this.maxY, this.propNorth, this.propEast, this.propSouth, this.propWest);
 
@@ -84,7 +84,7 @@ public class DecoVines extends DecoBase {
                     int intZ = worldZ + rand.nextInt(16);// + 8;
                     int intY = this.minY;
 
-                    worldGenerator.generate(rtgWorld.world, rand, new BlockPos(intX, intY, intZ));
+                    worldGenerator.generate(rtgWorld.world(), rand, new BlockPos(intX, intY, intZ));
                 }
             }
         }

--- a/src/main/java/rtg/api/world/deco/helper/DecoHelper5050.java
+++ b/src/main/java/rtg/api/world/deco/helper/DecoHelper5050.java
@@ -2,7 +2,7 @@ package rtg.api.world.deco.helper;
 
 import java.util.Random;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 
@@ -29,7 +29,7 @@ public class DecoHelper5050 extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 

--- a/src/main/java/rtg/api/world/deco/helper/DecoHelperBorder.java
+++ b/src/main/java/rtg/api/world/deco/helper/DecoHelperBorder.java
@@ -2,7 +2,7 @@ package rtg.api.world.deco.helper;
 
 import java.util.Random;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 
@@ -30,7 +30,7 @@ public class DecoHelperBorder extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (strength < noneBelow) {
             return; // border is too low

--- a/src/main/java/rtg/api/world/deco/helper/DecoHelperOneIn.java
+++ b/src/main/java/rtg/api/world/deco/helper/DecoHelperOneIn.java
@@ -8,7 +8,7 @@ package rtg.api.world.deco.helper;
 
 import java.util.Random;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 
@@ -26,7 +26,7 @@ public class DecoHelperOneIn extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 

--- a/src/main/java/rtg/api/world/deco/helper/DecoHelperRandomSplit.java
+++ b/src/main/java/rtg/api/world/deco/helper/DecoHelperRandomSplit.java
@@ -2,7 +2,7 @@ package rtg.api.world.deco.helper;
 
 import java.util.Random;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 
@@ -35,7 +35,7 @@ public class DecoHelperRandomSplit extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 

--- a/src/main/java/rtg/api/world/deco/helper/DecoHelperThisOrThat.java
+++ b/src/main/java/rtg/api/world/deco/helper/DecoHelperThisOrThat.java
@@ -8,7 +8,7 @@ package rtg.api.world.deco.helper;
 
 import java.util.Random;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 
@@ -36,7 +36,7 @@ public class DecoHelperThisOrThat extends DecoBase {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int chunkX, int chunkY, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed) {
 

--- a/src/main/java/rtg/api/world/surface/SurfaceBase.java
+++ b/src/main/java/rtg/api/world/surface/SurfaceBase.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.config.RTGConfig;
 import rtg.api.event.SurfaceEvent;
 import rtg.api.util.BlockUtil;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public abstract class SurfaceBase {
 
@@ -51,11 +51,11 @@ public abstract class SurfaceBase {
         this.assignUserConfigs(config, top, fill);
     }
 
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
     }
 
-    protected IBlockState getShadowStoneBlock(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+    protected IBlockState getShadowStoneBlock(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
         SurfaceEvent.HardcodedBlock event = new SurfaceEvent.HardcodedBlock(
             rtgWorld, i, j, x, y, k, shadowStoneBlock
@@ -65,7 +65,7 @@ public abstract class SurfaceBase {
         return event.getBlock();
     }
 
-    protected IBlockState getShadowDesertBlock(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+    protected IBlockState getShadowDesertBlock(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
         SurfaceEvent.HardcodedBlock event = new SurfaceEvent.HardcodedBlock(
             rtgWorld, i, j, x, y, k, shadowDesertBlock
@@ -75,12 +75,12 @@ public abstract class SurfaceBase {
         return event.getBlock();
     }
 
-    protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+    protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
         return cliffStoneBlock;
     }
 
-    protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+    protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
 
         SurfaceEvent.HardcodedBlock event = new SurfaceEvent.HardcodedBlock(
             rtgWorld, worldX, worldZ, chunkX, chunkZ, worldY, cliffCobbleBlock

--- a/src/main/java/rtg/api/world/surface/SurfaceGeneric.java
+++ b/src/main/java/rtg/api/world/surface/SurfaceGeneric.java
@@ -9,7 +9,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public class SurfaceGeneric extends SurfaceBase {
 
@@ -19,9 +19,9 @@ public class SurfaceGeneric extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
 
         for (int k = 255; k > -1; k--) {
             Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/api/world/surface/SurfaceOrganic.java
+++ b/src/main/java/rtg/api/world/surface/SurfaceOrganic.java
@@ -9,7 +9,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public class SurfaceOrganic extends SurfaceBase {
 
@@ -19,9 +19,9 @@ public class SurfaceOrganic extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
 
         for (int k = 255; k > -1; k--) {
             Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/api/world/surface/SurfaceRiverOasis.java
+++ b/src/main/java/rtg/api/world/surface/SurfaceRiverOasis.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.RTGAPI;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public class SurfaceRiverOasis extends SurfaceBase {
 
@@ -29,10 +29,10 @@ public class SurfaceRiverOasis extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
 
         IBlockState blockState;
         int highestY;

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceCanyon.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceCanyon.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CanyonColour;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceCanyon extends SurfaceBase {
@@ -25,9 +25,9 @@ public class SurfaceCanyon extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.3f;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceDesert.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceDesert.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceDesert extends SurfaceBase {
@@ -29,9 +29,9 @@ public class SurfaceDesert extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 2.8f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceDesertMountain.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceDesertMountain.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceDesertMountain extends SurfaceBase {
@@ -40,10 +40,10 @@ public class SurfaceDesertMountain extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceDesertOasis.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceDesertOasis.java
@@ -12,7 +12,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceDesertOasis extends SurfaceBase {
@@ -33,10 +33,10 @@ public class SurfaceDesertOasis extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.3f ? true : false;
         boolean dirt = false;

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceDuneValley.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceDuneValley.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceDuneValley extends SurfaceBase {
@@ -30,10 +30,10 @@ public class SurfaceDuneValley extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float h = (simplex.noise2(i / valley, j / valley) + 0.25f) * 65f;
         h = h < 1f ? 1f : h;
         float m = simplex.noise2(i / 12f, j / 12f);

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceGrassCanyon.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceGrassCanyon.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceGrassCanyon extends SurfaceBase {
@@ -25,9 +25,9 @@ public class SurfaceGrassCanyon extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.3f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceGrassland.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceGrassland.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceGrassland extends SurfaceBase {
@@ -27,9 +27,9 @@ public class SurfaceGrassland extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceGrasslandMix1.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceGrasslandMix1.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceGrasslandMix1 extends SurfaceBase {
@@ -35,10 +35,10 @@ public class SurfaceGrasslandMix1 extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceGrasslandMixBig.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceGrasslandMixBig.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceGrasslandMixBig extends SurfaceBase {
@@ -41,10 +41,10 @@ public class SurfaceGrasslandMixBig extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
         boolean mix = false;

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceIslandMountainStone.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceIslandMountainStone.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceIslandMountainStone extends SurfaceBase {
@@ -40,10 +40,10 @@ public class SurfaceIslandMountainStone extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMarshFix.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMarshFix.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMarshFix extends SurfaceBase {
@@ -27,9 +27,9 @@ public class SurfaceMarshFix extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMesa.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMesa.java
@@ -11,7 +11,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.CanyonColour;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMesa extends SurfaceBase {
@@ -41,9 +41,9 @@ public class SurfaceMesa extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.3f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMountainPolar.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMountainPolar.java
@@ -5,7 +5,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMountainPolar extends SurfaceBase {
@@ -19,7 +19,7 @@ public class SurfaceMountainPolar extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
     }
 }

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMountainSnow.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMountainSnow.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMountainSnow extends SurfaceBase {
@@ -46,10 +46,10 @@ public class SurfaceMountainSnow extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMountainStone.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMountainStone.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMountainStone extends SurfaceBase {
@@ -40,10 +40,10 @@ public class SurfaceMountainStone extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceMountainStoneMix1.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceMountainStoneMix1.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceMountainStoneMix1 extends SurfaceBase {
@@ -41,10 +41,10 @@ public class SurfaceMountainStoneMix1 extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;
         boolean m = false;

--- a/src/main/java/rtg/api/world/surface/templates/SurfacePolar.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfacePolar.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.SnowHeightCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfacePolar extends SurfaceBase {
@@ -22,10 +22,10 @@ public class SurfacePolar extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         boolean water = false;
         boolean riverPaint = false;
         boolean grass = false;

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceRedDesert.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceRedDesert.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceRedDesert extends SurfaceBase {
@@ -28,9 +28,9 @@ public class SurfaceRedDesert extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceRiverBOPCrag.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceRiverBOPCrag.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceRiverBOPCrag extends SurfaceBase {
@@ -31,9 +31,9 @@ public class SurfaceRiverBOPCrag extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
+        Random rand = rtgWorld.rand();
         float c = CliffCalculator.calc(x, z, noise);
         boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/api/world/surface/templates/SurfaceTundra.java
+++ b/src/main/java/rtg/api/world/surface/templates/SurfaceTundra.java
@@ -12,7 +12,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public class SurfaceTundra extends SurfaceBase {
@@ -23,10 +23,10 @@ public class SurfaceTundra extends SurfaceBase {
     }
 
     @Override
-    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-        Random rand = rtgWorld.rand;
-        OpenSimplexNoise simplex = rtgWorld.simplex;
+        Random rand = rtgWorld.rand();
+        OpenSimplexNoise simplex = rtgWorld.simplex();
         float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
         float c = CliffCalculator.calc(x, z, noise);
         int cliff = 0;

--- a/src/main/java/rtg/api/world/terrain/FunctionalTerrainBase.java
+++ b/src/main/java/rtg/api/world/terrain/FunctionalTerrainBase.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.heighteffect.HeightEffect;
 
 /**
@@ -11,7 +11,7 @@ public class FunctionalTerrainBase extends TerrainBase {
     protected HeightEffect height;
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
         return riverized(height.added(rtgWorld, x, y) + base, river);
     }

--- a/src/main/java/rtg/api/world/terrain/TerrainBase.java
+++ b/src/main/java/rtg/api/world/terrain/TerrainBase.java
@@ -5,7 +5,7 @@ import rtg.api.config.RTGConfig;
 import rtg.api.util.Bayesian;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.heighteffect.VariableRuggednessEffect;
 
 public abstract class TerrainBase {
@@ -775,5 +775,5 @@ public abstract class TerrainBase {
         return baseHeight + h * border;
     }
 
-    public abstract float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river);
+    public abstract float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river);
 }

--- a/src/main/java/rtg/api/world/terrain/TerrainOrganic.java
+++ b/src/main/java/rtg/api/world/terrain/TerrainOrganic.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 public class TerrainOrganic extends TerrainBase {
 
@@ -9,8 +9,8 @@ public class TerrainOrganic extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int z, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int z, float border, float river) {
 
-        return riverized(rtgWorld.organicBiomeGenerator.getHeightAt(x, z), river);
+        return riverized(rtgWorld.organicBiomeGenerator().getHeightAt(x, z), river);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/TerrainShowCellNoise.java
+++ b/src/main/java/rtg/api/world/terrain/TerrainShowCellNoise.java
@@ -2,7 +2,7 @@
 package rtg.api.world.terrain;
 
 import rtg.api.util.noise.SpacedCellOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  *
@@ -12,9 +12,10 @@ public class TerrainShowCellNoise extends TerrainBase {
 
     double riverSeparation = 40;
     double riverValleyLevel = 1f;
+
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
-        double riverFactor = ((SpacedCellOctave)(rtgWorld.cell.octave(0)))
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
+        double riverFactor = ((SpacedCellOctave)(rtgWorld.cell().octave(0)))
                 .eval(((double)x)/riverSeparation, ((double)y)/riverSeparation).interiorValue();
         if (riverFactor>riverValleyLevel) return 0; // no river effect
         double start = (float)(riverFactor/riverValleyLevel) -1f;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/AdjustableSpikeEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/AdjustableSpikeEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -20,9 +20,9 @@ public class AdjustableSpikeEffect extends HeightEffect {
     public float power = 1.6f;// usually a range of 1 to 2
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
         if (noise < minimumSimplex) {
             noise = minimumSimplex;
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/BlendedHillEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/BlendedHillEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -22,9 +22,9 @@ public class BlendedHillEffect extends HeightEffect {
     public HeightEffect subordinate;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength);
         noise = TerrainBase.blendedHillHeight(noise, hillBottomSimplexValue);
         if (subordinate == null) {
             return noise * height;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/BumpyHillsEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/BumpyHillsEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -26,11 +26,11 @@ public class BumpyHillsEffect extends HeightEffect {
     public int spikeOctave = 2;//
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(hillOctave).noise2(x / hillWavelength, y / hillWavelength);
+        float noise = rtgWorld.simplex().octave(hillOctave).noise2(x / hillWavelength, y / hillWavelength);
         noise = TerrainBase.blendedHillHeight(noise);
-        float spikeNoise = rtgWorld.simplex.octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
+        float spikeNoise = rtgWorld.simplex().octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
         spikeNoise = TerrainBase.blendedHillHeight(spikeNoise * noise);
         return noise * hillHeight + spikeNoise * spikeHeight;
     }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/GroundEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/GroundEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -17,9 +17,9 @@ public class GroundEffect extends HeightEffect {
     }
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        return TerrainBase.groundNoise(x, y, amplitude, rtgWorld.simplex);
+        return TerrainBase.groundNoise(x, y, amplitude, rtgWorld.simplex());
     }
 
 }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/HeightEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/HeightEffect.java
@@ -4,14 +4,14 @@
 
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * @author Zeno410
  */
 public abstract class HeightEffect {
 
-    public abstract float added(RTGWorld rtgWorld, float x, float y);
+    public abstract float added(IRTGWorld rtgWorld, float x, float y);
 
     public HeightEffect plus(HeightEffect added) {
 
@@ -30,7 +30,7 @@ public abstract class HeightEffect {
         }
 
         @Override
-        public float added(RTGWorld rtgWorld, float x, float y) {
+        public float added(IRTGWorld rtgWorld, float x, float y) {
 
             return one.added(rtgWorld, x, y) + two.added(rtgWorld, x, y);
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/HeightVariation.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/HeightVariation.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * @author Zeno410
@@ -14,9 +14,9 @@ public class HeightVariation extends HeightEffect {
     public int octave = -1;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        return rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength) * height;
+        return rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength) * height;
     }
 
 }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/HillockEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/HillockEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * @author Zeno410
@@ -18,9 +18,9 @@ public class HillockEffect extends HeightEffect {
     public int octave;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength);
         if (noise < minimumSimplex) {
             noise = 0;
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/HillsEverywhereEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/HillsEverywhereEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -22,9 +22,9 @@ public class HillsEverywhereEffect extends HeightEffect {
     public HeightEffect modified;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength);
         noise = Math.abs(noise);
         noise = TerrainBase.blendedHillHeight(noise, hillBottomSimplexValue);
         if (modified == null) {

--- a/src/main/java/rtg/api/world/terrain/heighteffect/JitterEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/JitterEffect.java
@@ -1,7 +1,7 @@
 package rtg.api.world.terrain.heighteffect;
 
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * This class returns a height effect with a jitter on the position.
@@ -28,13 +28,13 @@ public class JitterEffect extends HeightEffect {
     }
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
         if (running) {
             throw new RuntimeException();
         }
         running = true;
-        rtgWorld.simplex.riverJitter().evaluateNoise((float) x / wavelength, (float) y / wavelength, jitter);
+        rtgWorld.simplex().riverJitter().evaluateNoise((float) x / wavelength, (float) y / wavelength, jitter);
         int pX = (int) Math.round(x + jitter.deltax() * amplitude);
         int pY = (int) Math.round(y + jitter.deltay() * amplitude);
         running = false;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/LonelyMountainEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/LonelyMountainEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -24,15 +24,15 @@ public class LonelyMountainEffect extends HeightEffect {
     private float adjustedBottom = TerrainBase.blendedHillHeight(0, 0f);
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
+        float noise = rtgWorld.simplex().octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
         noise = Math.abs(noise);
         noise = TerrainBase.blendedHillHeight(noise, 0f);
         //transform to be more mountainous
         noise = TerrainBase.unsignedPower(noise, 1.7f);
         noise = 1f - (1f - noise) / (1f - adjustedBottom);
-        float spikeNoise = rtgWorld.simplex.octave(spikeOctave).noise2((float) x / spikeWavelength, (float) y / spikeWavelength);
+        float spikeNoise = rtgWorld.simplex().octave(spikeOctave).noise2((float) x / spikeWavelength, (float) y / spikeWavelength);
         spikeNoise = Math.abs(noise);
         spikeNoise = TerrainBase.blendedHillHeight(noise, 0f);
         spikeNoise *= noise;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/MountainsWithPassesEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/MountainsWithPassesEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -24,13 +24,13 @@ public class MountainsWithPassesEffect extends HeightEffect {
     private float adjustedBottom = TerrainBase.blendedHillHeight(0, .2f);
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
+        float noise = rtgWorld.simplex().octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
         noise = Math.abs(noise);
         noise = TerrainBase.blendedHillHeight(noise, 0.2f);
         noise = 1f - (1f - noise) / (1f - adjustedBottom);
-        float spikeNoise = rtgWorld.simplex.octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
+        float spikeNoise = rtgWorld.simplex().octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
         spikeNoise = Math.abs(noise);
         spikeNoise = TerrainBase.blendedHillHeight(noise, 0.1f);
         spikeNoise *= spikeNoise;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/PlateauEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/PlateauEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * @author Zeno410
@@ -22,9 +22,9 @@ public class PlateauEffect extends HeightEffect {
     public HeightEffect subordinate;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength);
         if (noise > topSimplexValue) {
             noise = 1f;
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/RaiseEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/RaiseEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * // just adds a constant increase
@@ -18,7 +18,7 @@ public class RaiseEffect extends HeightEffect {
     }
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
         return height;
     }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/ScatteredMountainsEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/ScatteredMountainsEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -26,11 +26,11 @@ public class ScatteredMountainsEffect extends HeightEffect {
     private float adjustedBottom = TerrainBase.blendedHillHeight(0, 0f);
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
+        float noise = rtgWorld.simplex().octave(hillOctave).noise2(x / mountainWavelength, y / mountainWavelength);
         noise = TerrainBase.blendedHillHeight(noise, 0f);
-        float spikeNoise = rtgWorld.simplex.octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
+        float spikeNoise = rtgWorld.simplex().octave(spikeOctave).noise2(x / spikeWavelength, y / spikeWavelength);
         spikeNoise = Math.abs(noise);
         spikeNoise = TerrainBase.blendedHillHeight(noise, 0f);
         spikeNoise *= spikeNoise;

--- a/src/main/java/rtg/api/world/terrain/heighteffect/SpikeEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/SpikeEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * @author Zeno410
@@ -18,9 +18,9 @@ public class SpikeEffect extends HeightEffect {
     public int octave;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2(x / wavelength, y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2(x / wavelength, y / wavelength);
         if (noise < minimumSimplex) {
             noise = minimumSimplex;
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/SpikeEverywhereEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/SpikeEverywhereEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 /**
@@ -21,9 +21,9 @@ public class SpikeEverywhereEffect extends HeightEffect {
     public HeightEffect spiked;
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float noise = rtgWorld.simplex.octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
+        float noise = rtgWorld.simplex().octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
         noise = Math.abs(noise);
         noise = TerrainBase.blendedHillHeight(noise, minimumSimplex);
         noise = TerrainBase.unsignedPower(noise, power);

--- a/src/main/java/rtg/api/world/terrain/heighteffect/VariableRuggednessEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/VariableRuggednessEffect.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.heighteffect;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * This provides a standard "ruggedness switch" between a rugged terrain and a smooth one
@@ -43,9 +43,9 @@ public class VariableRuggednessEffect extends HeightEffect {
     }
 
     @Override
-    public final float added(RTGWorld rtgWorld, float x, float y) {
+    public final float added(IRTGWorld rtgWorld, float x, float y) {
 
-        float choice = rtgWorld.simplex.octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
+        float choice = rtgWorld.simplex().octave(octave).noise2((float) x / wavelength, (float) y / wavelength);
         if (choice <= startTransition) {
             return smoothTerrain.added(rtgWorld, x, y);
         }

--- a/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiBasinEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiBasinEffect.java
@@ -5,7 +5,7 @@ import java.awt.geom.Point2D;
 
 import rtg.api.util.Bayesian;
 import rtg.api.util.noise.VoronoiResult;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 
 /**
@@ -20,16 +20,16 @@ public class VoronoiBasinEffect extends HeightEffect {
     public float adjustmentRadius = 1f;
     
     @Override
-    public float added(RTGWorld rtgWorld, float x, float y) {
+    public float added(IRTGWorld rtgWorld, float x, float y) {
         Point2D.Float evaluateAt = new Point2D.Float((float) x / pointWavelength,(float) y / pointWavelength);
-         VoronoiResult points = rtgWorld.voronoi.octave(1).eval(evaluateAt.x, evaluateAt.y); 
+         VoronoiResult points = rtgWorld.voronoi().octave(1).eval(evaluateAt.x, evaluateAt.y);
          float raise = (float) (points.borderValue());
          // now we're going to get an adjustment value which will be the same
          // for all points on a given vector from the voronoi basin center
          Point2D.Float adjustAt = points.toLength(evaluateAt, adjustmentRadius);
          float noZeros = 0.25f;
-         float adjustment = (float)rtgWorld.voronoi.octave(2).eval(adjustAt.x,adjustAt.y).interiorValue() + noZeros;
-         float reAdjustment = (float)rtgWorld.voronoi.octave(3).eval(adjustAt.x,adjustAt.y).interiorValue() + noZeros;;
+         float adjustment = (float)rtgWorld.voronoi().octave(2).eval(adjustAt.x,adjustAt.y).interiorValue() + noZeros;
+         float reAdjustment = (float)rtgWorld.voronoi().octave(3).eval(adjustAt.x,adjustAt.y).interiorValue() + noZeros;;
          // 0 to 1 which is currently undesirable so increase to average closer to 1
          adjustment = Bayesian.adjustment(adjustment, reAdjustment);
          // invert adjustment for Bryce

--- a/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiBorderEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiBorderEffect.java
@@ -1,7 +1,7 @@
 package rtg.api.world.terrain.heighteffect;
 
 import rtg.api.util.noise.VoronoiResult;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * This returns a value generally between just below 0 and 1 depending on the distance from a voronoi cell border
@@ -15,8 +15,8 @@ public class VoronoiBorderEffect extends HeightEffect {
     public float minimumDivisor = 0;//low divisors can produce excessive rates of change
     
     @Override
-    public float added(RTGWorld rtgWorld, float x, float y) {
-         VoronoiResult points = rtgWorld.cell.octave(1).eval((float) x / pointWavelength, (float) y / pointWavelength);      
+    public float added(IRTGWorld rtgWorld, float x, float y) {
+         VoronoiResult points = rtgWorld.cell().octave(1).eval((float) x / pointWavelength, (float) y / pointWavelength);
          float raise = (float) (points.interiorValue());
          raise = 1.0f-raise;
          //raise = TerrainBase.blendedHillHeight(raise, floor);

--- a/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiPlateauEffect.java
+++ b/src/main/java/rtg/api/world/terrain/heighteffect/VoronoiPlateauEffect.java
@@ -5,7 +5,7 @@ import java.awt.geom.Point2D;
 
 import rtg.api.util.Bayesian;
 import rtg.api.util.noise.VoronoiResult;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 
 /**
  * This returns a value generally between just below 0 and 1 depending on the distance from a voronoi cell border
@@ -19,17 +19,17 @@ public class VoronoiPlateauEffect extends HeightEffect {
     public float adjustmentRadius = 3f;
     
     @Override
-    public float added(RTGWorld rtgWorld, float x, float y) {
+    public float added(IRTGWorld rtgWorld, float x, float y) {
         Point2D.Float evaluateAt = new Point2D.Float((float) x / pointWavelength,(float) y / pointWavelength);
-         VoronoiResult points = rtgWorld.voronoi.octave(1).eval(evaluateAt.x, evaluateAt.y); 
+         VoronoiResult points = rtgWorld.voronoi().octave(1).eval(evaluateAt.x, evaluateAt.y);
          float raise = (float) (points.interiorValue());
          // now we're going to get an adjustment value which will be the same
          // for all points on a given vector from the voronoi basin center
          Point2D.Float adjustAt = points.toLength(evaluateAt, adjustmentRadius);
          float multiplier = 1.3f;
          float noZeros = 0.1f;
-         float adjustment = (float)rtgWorld.voronoi.octave(2).eval(adjustAt.x,adjustAt.y).interiorValue()*multiplier + noZeros;
-         float reAdjustment = (float)rtgWorld.voronoi.octave(3).eval(adjustAt.x,adjustAt.y).interiorValue()*multiplier + noZeros;;
+         float adjustment = (float)rtgWorld.voronoi().octave(2).eval(adjustAt.x,adjustAt.y).interiorValue()*multiplier + noZeros;
+         float reAdjustment = (float)rtgWorld.voronoi().octave(3).eval(adjustAt.x,adjustAt.y).interiorValue()*multiplier + noZeros;;
          // 0 to 1 which is currently undesirable so increase to average closer to 1
          adjustment = Bayesian.adjustment(adjustment, reAdjustment);
          raise = Bayesian.adjustment(raise, adjustment);

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainBeach.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainBeach.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainBeach extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainBeach extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 60f);
+        return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 60f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainCanyon.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainCanyon.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainCanyon extends TerrainBase {
@@ -49,17 +49,17 @@ public class TerrainCanyon extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
         //float b = simplex.noise2(x / cWidth, y / cWidth) * cHeigth * river;
         //b *= b / cStrength;
         river *= 1.3f;
         river = river > 1f ? 1f : river;
-        float r = rtgWorld.simplex.noise2(x / 100f, y / 100f) * 50f;
+        float r = rtgWorld.simplex().noise2(x / 100f, y / 100f) * 50f;
         r = r < -7.4f ? -7.4f : r > 7.4f ? 7.4f : r;
         float b = (17f + r) * river;
 
-        float hn = rtgWorld.simplex.noise2(x / 12f, y / 12f) * 0.5f;
+        float hn = rtgWorld.simplex().noise2(x / 12f, y / 12f) * 0.5f;
         float sb = 0f;
         if (b > 0f) {
             sb = b;
@@ -91,7 +91,7 @@ public class TerrainCanyon extends TerrainBase {
             }
         }
         else if (b < 5f) {
-            bn = (rtgWorld.simplex.noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex.noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
+            bn = (rtgWorld.simplex().noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex().noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
         }
 
         b += cTotal - bn;

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainDuneValley.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainDuneValley.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainDuneValley extends TerrainBase {
@@ -13,8 +13,8 @@ public class TerrainDuneValley extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainDuneValley(x, y, rtgWorld.simplex, rtgWorld.cell, river, valley, 65f, 70f);
+        return terrainDuneValley(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, valley, 65f, 70f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainDunes.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainDunes.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainDunes extends TerrainBase {
@@ -10,12 +10,12 @@ public class TerrainDunes extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        float st = (rtgWorld.simplex.noise2(x / 160f, y / 160f) + 0.38f) * (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get());
+        float st = (rtgWorld.simplex().noise2(x / 160f, y / 160f) + 0.38f) * (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get());
         st = st < 0.2f ? 0.2f : st;
 
-        float h = rtgWorld.simplex.noise2(x / 60f, y / 60f) * st * 2f;
+        float h = rtgWorld.simplex().noise2(x / 60f, y / 60f) * st * 2f;
         h = h > 0f ? -h : h;
         h += st;
         h *= h / 50f;
@@ -24,9 +24,9 @@ public class TerrainDunes extends TerrainBase {
         if (h < 10f) {
             float d = (h - 10f) / 2f;
             d = d > 4f ? 4f : d;
-            h += rtgWorld.cell.noise(x / 25D, y / 25D, 1D) * d;
-            h += rtgWorld.simplex.noise2(x / 30f, y / 30f) * d;
-            h += rtgWorld.simplex.noise2(x / 14f, y / 14f) * d * 0.5f;
+            h += rtgWorld.cell().noise(x / 25D, y / 25D, 1D) * d;
+            h += rtgWorld.simplex().noise2(x / 30f, y / 30f) * d;
+            h += rtgWorld.simplex().noise2(x / 14f, y / 14f) * d * 0.5f;
         }
 
         return 70f + (h * river);

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainFlatLakes.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainFlatLakes.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainFlatLakes extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainFlatLakes extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainFlatLakes(x, y, rtgWorld.simplex, river, 3f, 62f);
+        return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 3f, 62f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainForest.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainForest.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainForest extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainForest extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainForest(x, y, rtgWorld.simplex, river, 70f);
+        return terrainForest(x, y, rtgWorld.simplex(), river, 70f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandFlats.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandFlats.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainGrasslandFlats extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainGrasslandFlats extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainGrasslandFlats(x, y, rtgWorld.simplex, river, 40f, 25f, 68f);
+        return terrainGrasslandFlats(x, y, rtgWorld.simplex(), river, 40f, 25f, 68f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandHills.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandHills.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 
@@ -29,8 +29,8 @@ public class TerrainGrasslandHills extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, vWidth, vHeight, hWidth, hHeight, bHeight);
+        return terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, vWidth, vHeight, hWidth, hHeight, bHeight);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandMountains.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainGrasslandMountains.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainGrasslandMountains extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainGrasslandMountains extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 7f, 120f, 68f);
+        return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 7f, 120f, 68f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainHighland.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainHighland.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainHighland extends TerrainBase {
@@ -18,8 +18,8 @@ public class TerrainHighland extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+        return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainLonelyMountain.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainLonelyMountain.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainLonelyMountain extends TerrainBase {
@@ -16,8 +16,8 @@ public class TerrainLonelyMountain extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, base);
+        return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, base);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainMarsh.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainMarsh.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 
@@ -11,8 +11,8 @@ public class TerrainMarsh extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainMarsh(x, y, rtgWorld.simplex, 62f,river);
+        return terrainMarsh(x, y, rtgWorld.simplex(), 62f,river);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainMesa.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainMesa.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainMesa extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainMesa extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainMesa(x, y, rtgWorld.simplex, river, border);
+        return terrainMesa(x, y, rtgWorld.simplex(), river, border);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainMountain.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainMountain.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainMountain extends TerrainBase {
@@ -10,26 +10,26 @@ public class TerrainMountain extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        float h = rtgWorld.simplex.noise2(x / 300f, y / 300f) * 135f * river;
+        float h = rtgWorld.simplex().noise2(x / 300f, y / 300f) * 135f * river;
         h *= h / 32f;
         h = h > 150f ? 150f : h;
 
         if (h > 10f) {
             float d = (h - 10f) / 2f > 8f ? 8f : (h - 10f) / 2f;
-            h += rtgWorld.simplex.noise2(x / 35f, y / 35f) * d;
-            h += rtgWorld.simplex.noise2(x / 60f, y / 60f) * d * 0.5f;
+            h += rtgWorld.simplex().noise2(x / 35f, y / 35f) * d;
+            h += rtgWorld.simplex().noise2(x / 60f, y / 60f) * d * 0.5f;
 
             if (h > 35f) {
                 float d2 = (h - 35f) / 1.5f > 30f ? 30f : (h - 35f) / 1.5f;
-                h += rtgWorld.cell.noise(x / 25D, y / 25D, 1D) * d2;
+                h += rtgWorld.cell().noise(x / 25D, y / 25D, 1D) * d2;
             }
         }
 
-        h += rtgWorld.simplex.noise2(x / 28f, y / 28f) * 4;
-        h += rtgWorld.simplex.noise2(x / 18f, y / 18f) * 2;
-        h += rtgWorld.simplex.noise2(x / 8f, y / 8f) * 2;
+        h += rtgWorld.simplex().noise2(x / 28f, y / 28f) * 4;
+        h += rtgWorld.simplex().noise2(x / 18f, y / 18f) * 2;
+        h += rtgWorld.simplex().noise2(x / 8f, y / 8f) * 2;
 
         return h + 67f;
     }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainMountainRiver.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainMountainRiver.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainMountainRiver extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainMountainRiver extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainMountainRiver(x, y, rtgWorld.simplex, rtgWorld.cell, river, 300f, 67f);
+        return terrainMountainRiver(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 300f, 67f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainMountainSpikes.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainMountainSpikes.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainMountainSpikes extends TerrainBase {
@@ -10,26 +10,26 @@ public class TerrainMountainSpikes extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        float b = (12f + (rtgWorld.simplex.noise2(x / 300f, y / 300f) * 6f));
-        float h = rtgWorld.cell.noise(x / 200D, y / 200D, 1D) * b * river;
+        float b = (12f + (rtgWorld.simplex().noise2(x / 300f, y / 300f) * 6f));
+        float h = rtgWorld.cell().noise(x / 200D, y / 200D, 1D) * b * river;
         h *= h * 1.5f;
         h = h > 155f ? 155f : h;
 
         if (h > 2f) {
             float d = (h - 2f) / 2f > 8f ? 8f : (h - 2f) / 2f;
-            h += rtgWorld.simplex.noise2(x / 30f, y / 30f) * d;
-            h += rtgWorld.simplex.noise2(x / 50f, y / 50f) * d * 0.5f;
+            h += rtgWorld.simplex().noise2(x / 30f, y / 30f) * d;
+            h += rtgWorld.simplex().noise2(x / 50f, y / 50f) * d * 0.5f;
 
             if (h > 35f) {
                 float d2 = (h - 35f) / 1.5f > 30f ? 30f : (h - 35f) / 1.5f;
-                h += rtgWorld.cell.noise(x / 25D, y / 25D, 1D) * d2;
+                h += rtgWorld.cell().noise(x / 25D, y / 25D, 1D) * d2;
             }
         }
 
-        h += rtgWorld.simplex.noise2(x / 18f, y / 18f) * 3;
-        h += rtgWorld.simplex.noise2(x / 8f, y / 8f) * 2;
+        h += rtgWorld.simplex().noise2(x / 18f, y / 18f) * 3;
+        h += rtgWorld.simplex().noise2(x / 8f, y / 8f) * 2;
 
         return 45f + h + (b * 2);
     }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainOcean.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainOcean.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainOcean extends TerrainBase {
@@ -10,12 +10,12 @@ public class TerrainOcean extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        float h = rtgWorld.simplex.noise2(x / 300f, y / 300f) * 40f * river;
+        float h = rtgWorld.simplex().noise2(x / 300f, y / 300f) * 40f * river;
         h = h > 3f ? 3f : h;
-        h += rtgWorld.simplex.noise2(x / 50f, y / 50f) * (12f - h) * 0.4f;
-        h += rtgWorld.simplex.noise2(x / 15f, y / 15f) * (12f - h) * 0.15f;
+        h += rtgWorld.simplex().noise2(x / 50f, y / 50f) * (12f - h) * 0.4f;
+        h += rtgWorld.simplex().noise2(x / 15f, y / 15f) * (12f - h) * 0.15f;
 
         float floNoise = 50f + h;
         floNoise = floNoise < minimumOceanFloor ? minimumOceanFloor : floNoise;

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainOceanCanyon.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainOceanCanyon.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainOceanCanyon extends TerrainBase {
@@ -49,17 +49,17 @@ public class TerrainOceanCanyon extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
         //float b = simplex.noise2(x / cWidth, y / cWidth) * cHeigth * river;
         //b *= b / cStrength;
         river *= 1.3f;
         river = river > 1f ? 1f : river;
-        float r = rtgWorld.simplex.noise2(x / 100f, y / 100f) * 50f;
+        float r = rtgWorld.simplex().noise2(x / 100f, y / 100f) * 50f;
         r = r < -7.4f ? -7.4f : r > 7.4f ? 7.4f : r;
         float b = (17f + r) * river;
 
-        float hn = rtgWorld.simplex.noise2(x / 12f, y / 12f) * 0.5f;
+        float hn = rtgWorld.simplex().noise2(x / 12f, y / 12f) * 0.5f;
         float sb = 0f;
         if (b > 0f) {
             sb = b;
@@ -91,7 +91,7 @@ public class TerrainOceanCanyon extends TerrainBase {
             }
         }
         else if (b < 5f) {
-            bn = (rtgWorld.simplex.noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex.noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
+            bn = (rtgWorld.simplex().noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex().noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
         }
 
         b += cTotal - bn;

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainPlains.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainPlains.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainPlains extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainPlains extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 66f);
+        return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 66f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainPolar.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainPolar.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainPolar extends TerrainBase {
@@ -10,12 +10,12 @@ public class TerrainPolar extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        float st = (rtgWorld.simplex.noise2(x / 160f, y / 160f) + 0.38f) * (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get()) * river;
+        float st = (rtgWorld.simplex().noise2(x / 160f, y / 160f) + 0.38f) * (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get()) * river;
         st = st < 0.2f ? 0.2f : st;
 
-        float h = rtgWorld.simplex.noise2(x / 60f, y / 60f) * st * 2f;
+        float h = rtgWorld.simplex().noise2(x / 60f, y / 60f) * st * 2f;
         h = h > 0f ? -h : h;
         h += st;
         h *= h / 50f;

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainRollingHills.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainRollingHills.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainRollingHills extends TerrainBase {
@@ -19,11 +19,11 @@ public class TerrainRollingHills extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+        groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-        float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+        float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
         float floNoise = riverized(minHeight + groundNoise, river) + m;
 

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainSwampMountain.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainSwampMountain.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainSwampMountain extends TerrainBase {
@@ -15,8 +15,8 @@ public class TerrainSwampMountain extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainSwampMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, width, heigth, 150f, 32f, 56f);
+        return terrainSwampMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, width, heigth, 150f, 32f, 56f);
     }
 }

--- a/src/main/java/rtg/api/world/terrain/templates/TerrainVolcano.java
+++ b/src/main/java/rtg/api/world/terrain/templates/TerrainVolcano.java
@@ -1,6 +1,6 @@
 package rtg.api.world.terrain.templates;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.TerrainBase;
 
 public class TerrainVolcano extends TerrainBase {
@@ -10,8 +10,8 @@ public class TerrainVolcano extends TerrainBase {
     }
 
     @Override
-    public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+    public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-        return terrainVolcano(x, y, rtgWorld.simplex, rtgWorld.cell, border, 70f);
+        return terrainVolcano(x, y, rtgWorld.simplex(), rtgWorld.cell(), border, 70f);
     }
 }

--- a/src/main/java/rtg/world/RTGWorld.java
+++ b/src/main/java/rtg/world/RTGWorld.java
@@ -13,7 +13,9 @@ import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
 import rtg.api.world.IRTGWorld;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.api.world.biome.OrganicBiomeGenerator;
+import rtg.world.gen.LandscapeGenerator;
 
 /**
  * @author topisani
@@ -29,6 +31,7 @@ public class RTGWorld implements IRTGWorld {
     public final TimedHashSet<ChunkPos> decoratedChunks = new TimedHashSet(5000);
     public final BiomeMesa mesaBiome;
     public final OrganicBiomeGenerator organicBiomeGenerator;
+    public final LandscapeGenerator landscapeGenerator;
 
     public RTGWorld(World world) {
         this.world = world;
@@ -41,6 +44,7 @@ public class RTGWorld implements IRTGWorld {
         mesaBiome = (BiomeMesa)Biomes.MESA;
         mesaBiome.generateBands(world.getSeed());
         this.organicBiomeGenerator = new OrganicBiomeGenerator(this);
+        this.landscapeGenerator = new LandscapeGenerator(this);
     }
 
     @Override
@@ -86,5 +90,10 @@ public class RTGWorld implements IRTGWorld {
     @Override
     public OrganicBiomeGenerator organicBiomeGenerator() {
         return this.organicBiomeGenerator;
+    }
+
+    @Override
+    public int getBiomeDataAt(IBiomeProviderRTG cmr, int cx, int cz) {
+        return this.landscapeGenerator.getBiomeDataAt(cmr, cx, cz);
     }
 }

--- a/src/main/java/rtg/world/RTGWorld.java
+++ b/src/main/java/rtg/world/RTGWorld.java
@@ -1,4 +1,4 @@
-package rtg.api.world;
+package rtg.world;
 
 import java.util.Random;
 
@@ -12,12 +12,13 @@ import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.OrganicBiomeGenerator;
 
 /**
  * @author topisani
  */
-public class RTGWorld {
+public class RTGWorld implements IRTGWorld {
 
     public final World world;
     public final OpenSimplexNoise simplex;
@@ -40,5 +41,50 @@ public class RTGWorld {
         mesaBiome = (BiomeMesa)Biomes.MESA;
         mesaBiome.generateBands(world.getSeed());
         this.organicBiomeGenerator = new OrganicBiomeGenerator(this);
+    }
+
+    @Override
+    public World world() {
+        return this.world;
+    }
+
+    @Override
+    public OpenSimplexNoise simplex() {
+        return this.simplex;
+    }
+
+    @Override
+    public CellNoise cell() {
+        return this.cell;
+    }
+
+    @Override
+    public CellNoise voronoi() {
+        return this.voronoi;
+    }
+
+    @Override
+    public Random rand() {
+        return this.rand;
+    }
+
+    @Override
+    public SimplexOctave.Disk surfaceJitter() {
+        return this.surfaceJitter;
+    }
+
+    @Override
+    public TimedHashSet<ChunkPos> decoratedChunks() {
+        return this.decoratedChunks;
+    }
+
+    @Override
+    public BiomeMesa mesaBiome() {
+        return this.mesaBiome;
+    }
+
+    @Override
+    public OrganicBiomeGenerator organicBiomeGenerator() {
+        return this.organicBiomeGenerator;
     }
 }

--- a/src/main/java/rtg/world/biome/BiomeAnalyzer.java
+++ b/src/main/java/rtg/world/biome/BiomeAnalyzer.java
@@ -6,6 +6,7 @@ import net.minecraft.world.biome.Biome;
 
 import rtg.api.RTGAPI;
 import rtg.api.util.CircularSearchCreator;
+import rtg.api.world.biome.IRealisticBiome;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;
 
@@ -20,7 +21,7 @@ public class BiomeAnalyzer {
     private boolean [] beachBiome;
     private boolean [] landBiome;
     private int [] preferredBeach;
-    private RealisticBiomeBase [] savedJittered;
+    private IRealisticBiome [] savedJittered;
     private RealisticBiomeBase scenicLakeBiome = RealisticBiomeBase.getBiome(RTGAPI.config().SCENIC_LAKE_BIOME_ID.get());
     private RealisticBiomeBase scenicFrozenLakeBiome = RealisticBiomeBase.getBiome(RTGAPI.config().SCENIC_FROZEN_LAKE_BIOME_ID.get());
     private SmoothingSearchStatus beachSearch;
@@ -301,7 +302,7 @@ public class BiomeAnalyzer {
      *
      */
 
-    public void newRepair(int [] genLayerBiomes, RealisticBiomeBase [] jitteredBiomes, int [] biomeNeighborhood, int neighborhoodSize, float [] noise, float [] riverStrength) {
+    public void newRepair(int [] genLayerBiomes, IRealisticBiome[] jitteredBiomes, int [] biomeNeighborhood, int neighborhoodSize, float [] noise, float [] riverStrength) {
 
         int sampleSize = 8;
         RealisticBiomeBase realisticBiome;
@@ -349,7 +350,7 @@ public class BiomeAnalyzer {
             if (beachSearch.absent) break; //no point
             float beachBottom = 61.5f;
             if (noise[i]< beachBottom ||noise[i]>riverAdjusted(beachTop,riverStrength[i])) continue;// this block isn't beach level
-            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
+            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome());
             if (swampBiome[biomeID]) continue;// swamps are acceptable at beach level
             if (beachSearch.notHunted) {
                 beachSearch.hunt(biomeNeighborhood);
@@ -379,7 +380,7 @@ public class BiomeAnalyzer {
             if (landSearch.absent&&beachSearch.absent) break; //no point
             // skip if this block isn't above beach level, adjusted for river effect to prevent abrupt beach stops
             if (noise[i] < riverAdjusted(beachTop, riverStrength[i])) continue;
-            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
+            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome());
             // already land
             if (landBiome[biomeID]) continue;
             // swamps are acceptable above water
@@ -414,7 +415,7 @@ public class BiomeAnalyzer {
             if (oceanSearch.absent) break; //no point
             float oceanTop = 61.5f;
             if (noise[i]> oceanTop) continue;// too hight
-            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
+            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome());
             if (oceanBiome[biomeID]) continue;// obviously ocean is OK
             if (swampBiome[biomeID]) continue;// swamps are acceptable
             if (riverBiome[biomeID]) continue;// rivers stay rivers
@@ -434,13 +435,13 @@ public class BiomeAnalyzer {
         }
         // convert remainder below sea level to lake biome
         for (int i = 0; i < 256; i++) {
-            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome);
+            int biomeID = Biome.getIdForBiome(jitteredBiomes[i].baseBiome());
             if (noise[i]<=61.5&&!riverBiome[biomeID]) {
                 // check for river
                 if (!oceanBiome[biomeID] &&
                     !swampBiome[biomeID] &&
                     !beachBiome[biomeID]) {
-                    int riverReplacement = Biome.getIdForBiome(jitteredBiomes[i].riverBiome); // make river
+                    int riverReplacement = Biome.getIdForBiome(jitteredBiomes[i].riverBiome()); // make river
                     if (riverReplacement == Biome.getIdForBiome(Biomes.FROZEN_RIVER))
                         jitteredBiomes[i] = scenicFrozenLakeBiome;
                     else jitteredBiomes[i] = scenicLakeBiome;

--- a/src/main/java/rtg/world/biome/BiomeProviderRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeProviderRTG.java
@@ -22,6 +22,7 @@ import rtg.api.util.Bayesian;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.world.RTGWorld;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;

--- a/src/main/java/rtg/world/biome/BiomeProviderRTG.java
+++ b/src/main/java/rtg/world/biome/BiomeProviderRTG.java
@@ -22,7 +22,7 @@ import rtg.api.util.Bayesian;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.SpacedCellNoise;
-import rtg.api.world.RTGWorld;
+import rtg.world.RTGWorld;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;
 

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -15,7 +15,7 @@ import rtg.api.util.BiomeUtils;
 import rtg.api.util.Logger;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexCellularNoise;
-import rtg.api.world.RTGWorld;
+import rtg.world.RTGWorld;
 import rtg.api.world.biome.BiomeDecoratorRTG;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.biome.RealisticBiomeManager;

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeBase.java
@@ -15,7 +15,7 @@ import rtg.api.util.BiomeUtils;
 import rtg.api.util.Logger;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexCellularNoise;
-import rtg.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.BiomeDecoratorRTG;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.biome.RealisticBiomeManager;
@@ -27,6 +27,7 @@ import rtg.api.world.surface.SurfaceGeneric;
 import rtg.api.world.surface.SurfaceRiverOasis;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.TerrainOrganic;
+import rtg.world.RTGWorld;
 
 
 @SuppressWarnings({"WeakerAccess", "UnusedParameters", "unused"})
@@ -261,7 +262,8 @@ public abstract class RealisticBiomeBase implements IRealisticBiome {
         //return (float)Math.pow((pressure-shoreLevel)/(topLevel-shoreLevel),1.0);
     }
 
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    @Override
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         float riverRegion = !this.getConfig().ALLOW_RIVERS.get() ? 0f : river;
 
@@ -275,7 +277,7 @@ public abstract class RealisticBiomeBase implements IRealisticBiome {
         }
     }
 
-    protected void rReplaceWithRiver(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    protected void rReplaceWithRiver(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         float riverRegion = !this.getConfig().ALLOW_RIVERS.get() ? 0f : river;
 

--- a/src/main/java/rtg/world/biome/realistic/RealisticBiomeCreator.java
+++ b/src/main/java/rtg/world/biome/realistic/RealisticBiomeCreator.java
@@ -2,7 +2,7 @@ package rtg.world.biome.realistic;
 
 import net.minecraft.world.biome.Biome;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.collection.DecoCollectionBase;
@@ -101,7 +101,7 @@ public class RealisticBiomeCreator extends RealisticBiomeBase {
     }
 
     @Override
-    public float lakePressure(RTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize) {
+    public float lakePressure(IRTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize) {
         return this.iRealisticBiome.lakePressure(rtgWorld, x, y, border, lakeInterval, largeBendSize, mediumBendSize, smallBendSize);
     }
 

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACCoraliumInfestedSwamp.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACCoraliumInfestedSwamp.java
@@ -14,7 +14,7 @@ import com.shinoow.abyssalcraft.api.biome.ACBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -47,9 +47,9 @@ public class RealisticBiomeACCoraliumInfestedSwamp extends RealisticBiomeACBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f, river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f, river);
         }
     }
 
@@ -67,10 +67,10 @@ public class RealisticBiomeACCoraliumInfestedSwamp extends RealisticBiomeACBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklands.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklands.java
@@ -15,7 +15,7 @@ import com.shinoow.abyssalcraft.api.block.ACBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoShrub;
@@ -65,9 +65,9 @@ public class RealisticBiomeACDarklands extends RealisticBiomeACBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
 
         }
     }
@@ -106,10 +106,10 @@ public class RealisticBiomeACDarklands extends RealisticBiomeACBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsForest.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsForest.java
@@ -15,7 +15,7 @@ import com.shinoow.abyssalcraft.api.block.ACBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoGrass;
@@ -59,11 +59,11 @@ public class RealisticBiomeACDarklandsForest extends RealisticBiomeACBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex());
 
-            float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+            float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
             float floNoise = 65f + groundNoise + m;
 
@@ -105,10 +105,10 @@ public class RealisticBiomeACDarklandsForest extends RealisticBiomeACBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsHighland.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsHighland.java
@@ -14,7 +14,7 @@ import com.shinoow.abyssalcraft.api.biome.ACBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -62,9 +62,9 @@ public class RealisticBiomeACDarklandsHighland extends RealisticBiomeACBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base);
         }
     }
 
@@ -100,10 +100,10 @@ public class RealisticBiomeACDarklandsHighland extends RealisticBiomeACBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsMountains.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsMountains.java
@@ -15,7 +15,7 @@ import com.shinoow.abyssalcraft.api.block.ACBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.terrain.FunctionalTerrainBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightVariation;
@@ -122,10 +122,10 @@ public class RealisticBiomeACDarklandsMountains extends RealisticBiomeACBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/RealisticBiomeACDarklandsPlains.java
@@ -14,11 +14,11 @@ import com.shinoow.abyssalcraft.api.biome.ACBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeACDarklandsPlains extends RealisticBiomeACBase {
 
@@ -50,7 +50,7 @@ public class RealisticBiomeACDarklandsPlains extends RealisticBiomeACBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -70,10 +70,10 @@ public class RealisticBiomeACDarklandsPlains extends RealisticBiomeACBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/abyssalcraft/SurfaceACBase.java
+++ b/src/main/java/rtg/world/biome/realistic/abyssalcraft/SurfaceACBase.java
@@ -5,7 +5,7 @@ import net.minecraft.block.state.IBlockState;
 import com.shinoow.abyssalcraft.api.block.ACBlocks;
 
 import rtg.api.config.BiomeConfig;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 
 public abstract class SurfaceACBase extends SurfaceBase {
@@ -16,13 +16,13 @@ public abstract class SurfaceACBase extends SurfaceBase {
     }
 
     @Override
-    protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+    protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
         return ACBlocks.darkstone.getDefaultState();
     }
 
     @Override
-    protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+    protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
 
         return ACBlocks.darkstone_cobblestone.getDefaultState();
     }

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARBambooGrove.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARBambooGrove.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
-import rtg.api.world.terrain.TerrainBase;
-import rtg.api.world.terrain.heighteffect.*;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.*;
 
 public class RealisticBiomeARBambooGrove extends RealisticBiomeARBase {
 
@@ -84,7 +84,7 @@ public class RealisticBiomeARBambooGrove extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             float result = biomeHeight.added(rtgWorld, x, y);
             if (result < 60) {
@@ -133,10 +133,10 @@ public class RealisticBiomeARBambooGrove extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean gravel = false;

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARCoralReef.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARCoralReef.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -86,9 +86,9 @@ public class RealisticBiomeARCoralReef extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOceanCanyon(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, booRiver);
+            return terrainOceanCanyon(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, booRiver);
         }
     }
 
@@ -106,10 +106,10 @@ public class RealisticBiomeARCoralReef extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARDeepReef.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARDeepReef.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -46,9 +46,9 @@ public class RealisticBiomeARDeepReef extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOcean(x, y, rtgWorld.simplex, river, 40f);
+            return terrainOcean(x, y, rtgWorld.simplex(), river, 40f);
         }
     }
 
@@ -76,10 +76,10 @@ public class RealisticBiomeARDeepReef extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             for (int k = 255; k > -1; k--) {
                 Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARKelpForest.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARKelpForest.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -86,9 +86,9 @@ public class RealisticBiomeARKelpForest extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOceanCanyon(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, booRiver);
+            return terrainOceanCanyon(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, booRiver);
         }
     }
 
@@ -106,10 +106,10 @@ public class RealisticBiomeARKelpForest extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeAROrchard.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeAROrchard.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -49,9 +49,9 @@ public class RealisticBiomeAROrchard extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
         }
     }
 
@@ -69,10 +69,10 @@ public class RealisticBiomeAROrchard extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARTropicalHills.java
+++ b/src/main/java/rtg/world/biome/realistic/agriculturalrevolution/RealisticBiomeARTropicalHills.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeARTropicalHills extends RealisticBiomeARBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
         }
     }
 
@@ -92,10 +92,10 @@ public class RealisticBiomeARTropicalHills extends RealisticBiomeARBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean gravel = false;

--- a/src/main/java/rtg/world/biome/realistic/arsmagica/RealisticBiomeAMWitchwoodForest.java
+++ b/src/main/java/rtg/world/biome/realistic/arsmagica/RealisticBiomeAMWitchwoodForest.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoGrass;
@@ -52,11 +52,11 @@ public class RealisticBiomeAMWitchwoodForest extends RealisticBiomeAMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex());
 
-            float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+            float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
             float floNoise = 65f + groundNoise + m;
 
@@ -104,10 +104,10 @@ public class RealisticBiomeAMWitchwoodForest extends RealisticBiomeAMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGGravelBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGGravelBeach.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,9 +45,9 @@ public class RealisticBiomeATGGravelBeach extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 63f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 63f);
         }
     }
 
@@ -83,10 +83,10 @@ public class RealisticBiomeATGGravelBeach extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGScrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGScrubland.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -49,7 +49,7 @@ public class RealisticBiomeATGScrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 100f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -83,10 +83,10 @@ public class RealisticBiomeATGScrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f;
 

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGShrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGShrubland.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,7 +45,7 @@ public class RealisticBiomeATGShrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeATGShrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGSnowyGravelBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGSnowyGravelBeach.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,9 +45,9 @@ public class RealisticBiomeATGSnowyGravelBeach extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 63f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 63f);
         }
     }
 
@@ -83,10 +83,10 @@ public class RealisticBiomeATGSnowyGravelBeach extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGTropicalShrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGTropicalShrubland.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,7 +45,7 @@ public class RealisticBiomeATGTropicalShrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeATGTropicalShrubland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGTundra.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGTundra.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,7 +51,7 @@ public class RealisticBiomeATGTundra extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 100f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -94,10 +94,10 @@ public class RealisticBiomeATGTundra extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             float mixNoise;
             boolean cliff = c > 1.4f;

--- a/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGWoodland.java
+++ b/src/main/java/rtg/world/biome/realistic/atg/RealisticBiomeATGWoodland.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,7 +45,7 @@ public class RealisticBiomeATGWoodland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeATGWoodland extends RealisticBiomeATGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/betteragriculture/RealisticBiomeBAFarmlandBiome.java
+++ b/src/main/java/rtg/world/biome/realistic/betteragriculture/RealisticBiomeBAFarmlandBiome.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -55,11 +55,11 @@ class RealisticBiomeBAFarmlandBiome extends rtg.world.biome.realistic.betteragri
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -105,10 +105,10 @@ class RealisticBiomeBAFarmlandBiome extends rtg.world.biome.realistic.betteragri
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/DecoBOPBaseBiomeDecorations.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/DecoBOPBaseBiomeDecorations.java
@@ -7,7 +7,7 @@ import net.minecraft.util.math.ChunkPos;
 
 import biomesoplenty.api.generation.GeneratorStage;
 
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.biome.IRealisticBiome;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 
@@ -24,14 +24,14 @@ public class DecoBOPBaseBiomeDecorations extends DecoBaseBiomeDecorations {
     }
 
     @Override
-    public void generate(IRealisticBiome biome, RTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
+    public void generate(IRealisticBiome biome, IRTGWorld rtgWorld, Random rand, int worldX, int worldZ, float strength, float river, boolean hasPlacedVillageBlocks) {
 
         if (this.allowed && biome instanceof IRealisticBOPBiome) {
 
             // skip if already decorated (@author Zeno410, lifted from DecoSingleBiomeDecorations)
             ChunkPos position = new ChunkPos(worldX,worldZ);
-            if (rtgWorld.decoratedChunks.contains(position)) return;
-            rtgWorld.decoratedChunks.add(position);
+            if (rtgWorld.decoratedChunks().contains(position)) return;
+            rtgWorld.decoratedChunks().add(position);
 
             IRealisticBOPBiome bopBiome = (IRealisticBOPBiome) biome;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPAlps.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPAlps.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -54,9 +54,9 @@ public class RealisticBiomeBOPAlps extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
             //return terrainMountainRiver(x, y, simplex, cell, river, 300f, 67f);
         }
     }
@@ -99,10 +99,10 @@ public class RealisticBiomeBOPAlps extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBambooForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBambooForest.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.*;
@@ -87,7 +87,7 @@ public class RealisticBiomeBOPBambooForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             float result = biomeHeight.added(rtgWorld, x, y);
             return riverized(result,river);
@@ -129,10 +129,10 @@ public class RealisticBiomeBOPBambooForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBayou.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBayou.java
@@ -19,10 +19,11 @@ import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
 import rtg.api.util.noise.VoronoiResult;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 import static rtg.api.world.deco.DecoFallenTree.LogCondition.NOISE_GREATER_AND_RANDOM_CHANCE;
 
 public class RealisticBiomeBOPBayou extends RealisticBiomeBOPBase {
@@ -65,9 +66,9 @@ public class RealisticBiomeBOPBayou extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 80f, 1f, 40f, 20f, 62f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 80f, 1f, 40f, 20f, 62f);
         }
     }
 
@@ -105,10 +106,10 @@ public class RealisticBiomeBOPBayou extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;
@@ -178,12 +179,12 @@ public class RealisticBiomeBOPBayou extends RealisticBiomeBOPBase {
     }
 
     @Override
-    public float lakePressure(RTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize)
+    public float lakePressure(IRTGWorld rtgWorld, int x, int y, float border, float lakeInterval, float largeBendSize, float mediumBendSize, float smallBendSize)
             // so, rather than lakes, we have a bayou network
     {
     	//this code is borrowed from WorldChunkManagerRTG with vars changes
             SimplexOctave.Disk jitter = new SimplexOctave.Disk();
-            rtgWorld.simplex.riverJitter().evaluateNoise((float)x / 40.0, (float)y / 40.0, jitter);
+            rtgWorld.simplex().riverJitter().evaluateNoise((float)x / 40.0, (float)y / 40.0, jitter);
             double pX = x + jitter.deltax() * 35f;
             double pY = y + jitter.deltay() * 35f;
             /*double[] simplexResults = new double[2];
@@ -193,7 +194,7 @@ public class RealisticBiomeBOPBayou extends RealisticBiomeBOPBase {
 
         //New cellular noise.
         //TODO move the initialization of the results in a way that's more efficient but still thread safe.
-        VoronoiResult results = rtgWorld.cell.river().eval(pX / 150.0, pY / 150.0);
+        VoronoiResult results = rtgWorld.cell().river().eval(pX / 150.0, pY / 150.0);
         if (border<.5) border = .5f;
         float result = (float)(results.interiorValue());
         // that will leave rivers too small

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBog.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBog.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightVariation;
@@ -68,7 +68,7 @@ public class RealisticBiomeBOPBog extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             float increment = bottomVariation.added(rtgWorld, x, y) + smallHills.added(rtgWorld, x, y);
             increment += mediumHills.added(rtgWorld, x, y);
@@ -90,9 +90,9 @@ public class RealisticBiomeBOPBog extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBorealForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBorealForest.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.BumpyHillsEffect;
@@ -65,9 +65,9 @@ public class RealisticBiomeBOPBorealForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
 
             float m = hillEffect.added(rtgWorld, x, y);
@@ -110,10 +110,10 @@ public class RealisticBiomeBOPBorealForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBrushland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPBrushland.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -53,11 +53,11 @@ public class RealisticBiomeBOPBrushland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+            float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
             return riverized(baseHeight + groundNoise + m,river);
         }
@@ -86,10 +86,10 @@ public class RealisticBiomeBOPBrushland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPChaparral.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPChaparral.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -62,16 +62,16 @@ public class RealisticBiomeBOPChaparral extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
             //float m = hills(x, y, peakyHillStrength, simplex, river);
 
-            rtgWorld.simplex.riverJitter().evaluateNoise((float) x / wavelength, (float) y / wavelength, jitter);
+            rtgWorld.simplex().riverJitter().evaluateNoise((float) x / wavelength, (float) y / wavelength, jitter);
             int pX = (int) Math.round(x + jitter.deltax() * amplitude);
             int pY = (int) Math.round(y + jitter.deltay() * amplitude);
-            float h = this.terrainGrasslandHills(pX, pY, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = this.terrainGrasslandHills(pX, pY, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return groundNoise*river + h;
         }
@@ -100,10 +100,10 @@ public class RealisticBiomeBOPChaparral extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCherryBlossomGrove.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCherryBlossomGrove.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -61,9 +61,9 @@ public class RealisticBiomeBOPCherryBlossomGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -107,10 +107,10 @@ public class RealisticBiomeBOPCherryBlossomGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPColdDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPColdDesert.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.SnowHeightCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -49,9 +49,9 @@ public class RealisticBiomeBOPColdDesert extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            float result = terrainPlains(x, y, rtgWorld.simplex, river, ruggednessWavelength, ruggedness, heightPitch, heightDivisor, base);
+            float result = terrainPlains(x, y, rtgWorld.simplex(), river, ruggednessWavelength, ruggedness, heightPitch, heightDivisor, base);
             // no indentations; cutoff is not noticeable with these low slopes
             return result > base ? result : base;
         }
@@ -96,10 +96,10 @@ public class RealisticBiomeBOPColdDesert extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             boolean water = false;
             boolean riverPaint = false;
             boolean grass = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPConiferousForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPConiferousForest.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -60,9 +60,9 @@ public class RealisticBiomeBOPConiferousForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -106,10 +106,10 @@ public class RealisticBiomeBOPConiferousForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCoralReef.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCoralReef.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -85,9 +85,9 @@ public class RealisticBiomeBOPCoralReef extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOceanCanyon(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, booRiver);
+            return terrainOceanCanyon(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, booRiver);
         }
     }
 
@@ -105,9 +105,9 @@ public class RealisticBiomeBOPCoralReef extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCrag.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPCrag.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoPond;
 import rtg.api.world.deco.helper.DecoHelperBorder;
 import rtg.api.world.surface.SurfaceBase;
@@ -97,17 +97,17 @@ public class RealisticBiomeBOPCrag extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             //float b = simplex.noise2(x / cWidth, y / cWidth) * cHeigth * river;
             //b *= b / cStrength;
             river *= 1.3f;
             river = river > 1f ? 1f : river;
-            float r = rtgWorld.simplex.noise2(x / 100f, y / 100f) * 50f;
+            float r = rtgWorld.simplex().noise2(x / 100f, y / 100f) * 50f;
             r = r < -7.4f ? -7.4f : r > 7.4f ? 7.4f : r;
             float b = (17f + r) * river;
 
-            float hn = rtgWorld.simplex.noise2(x / 12f, y / 12f) * 0.5f;
+            float hn = rtgWorld.simplex().noise2(x / 12f, y / 12f) * 0.5f;
             float sb = 0f;
             if(b > 0f)
             {
@@ -146,7 +146,7 @@ public class RealisticBiomeBOPCrag extends RealisticBiomeBOPBase {
             }
             else if(b < 5f)
             {
-                bn = (rtgWorld.simplex.noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex.noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
+                bn = (rtgWorld.simplex().noise2(x / 7f, y / 7f) * 1.3f + rtgWorld.simplex().noise2(x / 15f, y / 15f) * 2f) * (5f - b) * 0.2f;
             }
 
             b += cTotal - bn;
@@ -189,10 +189,10 @@ public class RealisticBiomeBOPCrag extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;
@@ -266,7 +266,7 @@ public class RealisticBiomeBOPCrag extends RealisticBiomeBOPBase {
         }
 
         @Override
-        protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+        protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
             return cragRock;
         }
     }

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPDeadForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPDeadForest.java
@@ -16,7 +16,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -67,9 +67,9 @@ public class RealisticBiomeBOPDeadForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, deadForestGroundAmplitude, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, deadForestGroundAmplitude, 0f);
         }
     }
 
@@ -113,10 +113,10 @@ public class RealisticBiomeBOPDeadForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPDeadSwamp.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPDeadSwamp.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.block.BOPBlocks;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightEffect;
@@ -56,7 +56,7 @@ public class RealisticBiomeBOPDeadSwamp extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return 62f + height.added(rtgWorld, x, y);
         }
@@ -81,9 +81,9 @@ public class RealisticBiomeBOPDeadSwamp extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 
@@ -113,7 +113,7 @@ public class RealisticBiomeBOPDeadSwamp extends RealisticBiomeBOPBase {
                     else {
                         if (depth == 0 && k > 61) {
                             
-                            if (rtgWorld.simplex.octave(2).noise2(i / 12f, j / 12f) > mixHeight + (noise[x * 16 + z]-63f)/10f) {
+                            if (rtgWorld.simplex().octave(2).noise2(i / 12f, j / 12f) > mixHeight + (noise[x * 16 + z]-63f)/10f) {
                                 primer.setBlockState(x, k, z, mix);
                             }
                             else {

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPEucalyptusForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPEucalyptusForest.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.helper.DecoHelper5050;
@@ -59,11 +59,11 @@ public class RealisticBiomeBOPEucalyptusForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -109,10 +109,10 @@ public class RealisticBiomeBOPEucalyptusForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFen.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFen.java
@@ -16,7 +16,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -56,9 +56,9 @@ public class RealisticBiomeBOPFen extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -102,10 +102,10 @@ public class RealisticBiomeBOPFen extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFlowerField.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFlowerField.java
@@ -15,7 +15,7 @@ import static biomesoplenty.api.generation.GeneratorStage.FLOWERS;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFlowersRTG;
 import rtg.api.world.deco.DecoPond;
 import rtg.api.world.deco.DecoShrub;
@@ -50,9 +50,9 @@ public class RealisticBiomeBOPFlowerField extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 65f);
         }
     }
 
@@ -90,10 +90,10 @@ public class RealisticBiomeBOPFlowerField extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFlowerIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPFlowerIsland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -56,9 +56,9 @@ public class RealisticBiomeBOPFlowerIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
         }
     }
 
@@ -76,9 +76,9 @@ public class RealisticBiomeBOPFlowerIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGlacier.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGlacier.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -50,9 +50,9 @@ public class RealisticBiomeBOPGlacier extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, base);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, base);
         }
     }
 
@@ -90,10 +90,10 @@ public class RealisticBiomeBOPGlacier extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGrassland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGrassland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPGrassland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 66f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 66f);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPGrassland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGravelBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGravelBeach.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -48,9 +48,9 @@ public class RealisticBiomeBOPGravelBeach extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 60f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 60f);
         }
     }
 
@@ -86,10 +86,10 @@ public class RealisticBiomeBOPGravelBeach extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f ? true : false;
             boolean dirt = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGrove.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPGrove.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoFlowersRTG;
 import rtg.api.world.deco.DecoGrass;
@@ -61,10 +61,10 @@ public class RealisticBiomeBOPGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             // no ground noise
 
-            float h = this.terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, smoothHillWavelength, smoothHillStrength, peakyHillWavelength, peakyHillStrength, baseHeight);
+            float h = this.terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, smoothHillWavelength, smoothHillStrength, peakyHillWavelength, peakyHillStrength, baseHeight);
 
             return h;
         }
@@ -103,10 +103,10 @@ public class RealisticBiomeBOPGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPHeathland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPHeathland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -59,9 +59,9 @@ public class RealisticBiomeBOPHeathland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            float added = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            float added = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
             added += hills.added(rtgWorld, x, y);
             return riverized(baseHeight + added, river);
         }
@@ -81,9 +81,9 @@ public class RealisticBiomeBOPHeathland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPHighland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPHighland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.BumpyHillsEffect;
@@ -61,9 +61,9 @@ public class RealisticBiomeBOPHighland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return riverized(baseHeight + withJitter.added(rtgWorld, x, y) + this.groundNoise(x, y, 6, rtgWorld.simplex), river);
+            return riverized(baseHeight + withJitter.added(rtgWorld, x, y) + this.groundNoise(x, y, 6, rtgWorld.simplex()), river);
             //return terrainGrasslandMountains(x, y, simplex, cell, river, 4f, 80f, 68f);
         }
     }
@@ -82,9 +82,9 @@ public class RealisticBiomeBOPHighland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPKelpForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPKelpForest.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -85,9 +85,9 @@ public class RealisticBiomeBOPKelpForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOceanCanyon(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, booRiver);
+            return terrainOceanCanyon(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, booRiver);
         }
     }
 
@@ -105,9 +105,9 @@ public class RealisticBiomeBOPKelpForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLandOfLakes.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLandOfLakes.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoShrub;
@@ -95,7 +95,7 @@ public class RealisticBiomeBOPLandOfLakes extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             return riverized(largeJitter.added(rtgWorld, x, y)+ this.base,river);
             //return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
@@ -135,10 +135,10 @@ public class RealisticBiomeBOPLandOfLakes extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLavenderFields.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLavenderFields.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoGrass;
 import rtg.api.world.deco.DecoShrub;
 import rtg.api.world.surface.SurfaceBase;
@@ -46,9 +46,9 @@ public class RealisticBiomeBOPLavenderFields extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 66f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 66f);
         }
     }
 
@@ -86,10 +86,10 @@ public class RealisticBiomeBOPLavenderFields extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLushDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLushDesert.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoJungleCacti;
@@ -87,7 +87,7 @@ public class RealisticBiomeBOPLushDesert extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(minHeight + groundEffect.added(rtgWorld, x, y), river) + height.added(rtgWorld, x, y);
             //return terrainRollingHills(x, y, simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
@@ -134,10 +134,10 @@ public class RealisticBiomeBOPLushDesert extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 3.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLushSwamp.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPLushSwamp.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeBOPLushSwamp extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
             //return terrainBeach(x, y, simplex, river, 180f, 35f, 60f);
         }
     }
@@ -71,9 +71,9 @@ public class RealisticBiomeBOPLushSwamp extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMangrove.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMangrove.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,8 +43,8 @@ public class RealisticBiomeBOPMangrove extends RealisticBiomeBOPBase {
 		}
 
 		@Override
-		public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
-			return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 60f);
+		public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
+			return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 60f);
 		}
 	}
 
@@ -62,9 +62,9 @@ public class RealisticBiomeBOPMangrove extends RealisticBiomeBOPBase {
 		}
 
 		@Override
-		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-			Random rand = rtgWorld.rand;
+			Random rand = rtgWorld.rand();
 			float c = CliffCalculator.calc(x, z, noise);
 			boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMapleWoods.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMapleWoods.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -57,9 +57,9 @@ public class RealisticBiomeBOPMapleWoods extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, river);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, river);
         }
     }
 
@@ -77,9 +77,9 @@ public class RealisticBiomeBOPMapleWoods extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMarsh.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMarsh.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightVariation;
@@ -57,7 +57,7 @@ public class RealisticBiomeBOPMarsh extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return baseHeight + variation.added(rtgWorld, x, y) + smallVariation.added(rtgWorld, x, y);
         }
@@ -77,9 +77,9 @@ public class RealisticBiomeBOPMarsh extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMeadow.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMeadow.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPMeadow extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 66f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 66f);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPMeadow extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMoor.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMoor.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.block.BOPBlocks;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -58,9 +58,9 @@ public class RealisticBiomeBOPMoor extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, lift);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, lift);
         }
     }
 
@@ -78,9 +78,9 @@ public class RealisticBiomeBOPMoor extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMountainFoothills.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMountainFoothills.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -58,11 +58,11 @@ public class RealisticBiomeBOPMountainFoothills extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+            float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
             return riverized(baseHeight + groundNoise + m, river)  ;
         }
@@ -108,10 +108,10 @@ public class RealisticBiomeBOPMountainFoothills extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMountainPeaks.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMountainPeaks.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoGrass;
@@ -85,7 +85,7 @@ public class RealisticBiomeBOPMountainPeaks extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(heightEffect.added(rtgWorld, x, y) + terrainHeight, river);
         }
@@ -131,10 +131,10 @@ public class RealisticBiomeBOPMountainPeaks extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMysticGrove.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPMysticGrove.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.block.BOPBlocks;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeBOPMysticGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 66f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 66f);
         }
     }
 
@@ -70,9 +70,9 @@ public class RealisticBiomeBOPMysticGrove extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOasis.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOasis.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeBOPOasis extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 100f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 100f, 65f);
         }
     }
 
@@ -97,10 +97,10 @@ public class RealisticBiomeBOPOasis extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOminousWoods.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOminousWoods.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.block.BOPBlocks;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -57,9 +57,9 @@ public class RealisticBiomeBOPOminousWoods extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -77,9 +77,9 @@ public class RealisticBiomeBOPOminousWoods extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOrchard.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOrchard.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -57,9 +57,9 @@ RealisticBiomeBOPOrchard extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
         }
     }
 
@@ -77,9 +77,9 @@ RealisticBiomeBOPOrchard extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOriginIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOriginIsland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -50,9 +50,9 @@ public class RealisticBiomeBOPOriginIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -70,9 +70,9 @@ public class RealisticBiomeBOPOriginIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOutback.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOutback.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.*;
@@ -82,7 +82,7 @@ public class RealisticBiomeBOPOutback extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(minHeight + groundEffect.added(rtgWorld, x, y), river) + height.added(rtgWorld, x, y);
             //return terrainRollingHills(x, y, simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
@@ -129,10 +129,10 @@ public class RealisticBiomeBOPOutback extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 4.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOvergrownCliffs.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPOvergrownCliffs.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -72,9 +72,9 @@ public class RealisticBiomeBOPOvergrownCliffs extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, terrainHeight);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, terrainHeight);
         }
     }
 
@@ -110,10 +110,10 @@ public class RealisticBiomeBOPOvergrownCliffs extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPPrairie.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPPrairie.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -52,9 +52,9 @@ public class RealisticBiomeBOPPrairie extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return this.terrainPlains(x, y, rtgWorld.simplex, river, 200f, 1f, 30f, 1f, maxHeight);
+            return this.terrainPlains(x, y, rtgWorld.simplex(), river, 200f, 1f, 30f, 1f, maxHeight);
         }
     }
 
@@ -72,9 +72,9 @@ public class RealisticBiomeBOPPrairie extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPQuagmire.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPQuagmire.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPQuagmire extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPQuagmire extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPRainforest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPRainforest.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -49,9 +49,9 @@ public class RealisticBiomeBOPRainforest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainSwampMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, width, heigth, 140f, 39f, 65f);
+            return terrainSwampMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, width, heigth, 140f, 39f, 65f);
         }
     }
 
@@ -87,10 +87,10 @@ public class RealisticBiomeBOPRainforest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPRedwoodForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPRedwoodForest.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.helper.DecoHelper5050;
@@ -62,9 +62,9 @@ public class RealisticBiomeBOPRedwoodForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -100,10 +100,10 @@ public class RealisticBiomeBOPRedwoodForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSacredSprings.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSacredSprings.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -55,9 +55,9 @@ public class RealisticBiomeBOPSacredSprings extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, terrainHeight);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, terrainHeight);
 
         }
     }
@@ -76,9 +76,9 @@ public class RealisticBiomeBOPSacredSprings extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSeasonalForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSeasonalForest.java
@@ -15,7 +15,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -61,9 +61,9 @@ public class RealisticBiomeBOPSeasonalForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, 0f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, 0f);
         }
     }
 
@@ -107,10 +107,10 @@ public class RealisticBiomeBOPSeasonalForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPShield.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPShield.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.helper.DecoHelper5050;
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPShield extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 64f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 64f);
         }
     }
 
@@ -83,9 +83,9 @@ public class RealisticBiomeBOPShield extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPShrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPShrubland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPShrubland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 100f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 100f, 65f);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPShrubland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSnowyConiferousForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSnowyConiferousForest.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -61,9 +61,9 @@ public class RealisticBiomeBOPSnowyConiferousForest extends RealisticBiomeBOPBas
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills + 2f, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills + 2f, 4f);
         }
     }
 
@@ -105,10 +105,10 @@ public class RealisticBiomeBOPSnowyConiferousForest extends RealisticBiomeBOPBas
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSnowyForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSnowyForest.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -55,9 +55,9 @@ public class RealisticBiomeBOPSnowyForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
         }
     }
 
@@ -101,10 +101,10 @@ public class RealisticBiomeBOPSnowyForest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSteppe.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPSteppe.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -52,9 +52,9 @@ public class RealisticBiomeBOPSteppe extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 4f);
         }
     }
 
@@ -72,9 +72,9 @@ public class RealisticBiomeBOPSteppe extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTemperateRainforest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTemperateRainforest.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -44,9 +44,9 @@ public class RealisticBiomeBOPTemperateRainforest extends RealisticBiomeBOPBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 100f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 100f, 65f);
         }
     }
 
@@ -82,10 +82,10 @@ public class RealisticBiomeBOPTemperateRainforest extends RealisticBiomeBOPBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalIsland.java
@@ -15,7 +15,7 @@ import biomesoplenty.api.block.BOPBlocks;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeBOPTropicalIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 160f, 30f, 65f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 160f, 30f, 65f);
         }
     }
 
@@ -97,10 +97,10 @@ public class RealisticBiomeBOPTropicalIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalRainforest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTropicalRainforest.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -55,9 +55,9 @@ public class RealisticBiomeBOPTropicalRainforest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
         }
     }
 
@@ -75,9 +75,9 @@ public class RealisticBiomeBOPTropicalRainforest extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTundra.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPTundra.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPTundra extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 100f, 66f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 100f, 66f);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPTundra extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPVolcanicIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPVolcanicIsland.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoGrassDoubleTallgrass;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeBOPVolcanicIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainVolcano(x, y, rtgWorld.simplex, rtgWorld.cell, border, 70f);
+            return terrainVolcano(x, y, rtgWorld.simplex(), rtgWorld.cell(), border, 70f);
         }
     }
 
@@ -96,10 +96,10 @@ public class RealisticBiomeBOPVolcanicIsland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWasteland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWasteland.java
@@ -13,7 +13,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -43,9 +43,9 @@ public class RealisticBiomeBOPWasteland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 100f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 100f, 65f);
         }
     }
 
@@ -63,9 +63,9 @@ public class RealisticBiomeBOPWasteland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWetland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWetland.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.block.BOPBlocks;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 
@@ -44,9 +44,9 @@ public class RealisticBiomeBOPWetland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -64,9 +64,9 @@ public class RealisticBiomeBOPWetland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWoodland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPWoodland.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionBase;
 import rtg.api.world.deco.helper.DecoHelper5050;
@@ -61,9 +61,9 @@ public class RealisticBiomeBOPWoodland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
         }
     }
 
@@ -81,9 +81,9 @@ public class RealisticBiomeBOPWoodland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPXericShrubland.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesoplenty/RealisticBiomeBOPXericShrubland.java
@@ -14,7 +14,7 @@ import biomesoplenty.api.biome.BOPBiomes;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.*;
@@ -81,7 +81,7 @@ public class RealisticBiomeBOPXericShrubland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(minHeight + groundEffect.added(rtgWorld, x, y), river) + height.added(rtgWorld, x, y);
         }
@@ -127,10 +127,10 @@ public class RealisticBiomeBOPXericShrubland extends RealisticBiomeBOPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 2.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGAthuraForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGAthuraForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoGrass;
@@ -62,11 +62,11 @@ public class RealisticBiomeBYGAthuraForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -112,10 +112,10 @@ public class RealisticBiomeBYGAthuraForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGAutumnForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGAutumnForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGQuercusRobur;
@@ -62,11 +62,11 @@ public class RealisticBiomeBYGAutumnForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -112,10 +112,10 @@ public class RealisticBiomeBYGAutumnForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGBirchPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGBirchPlains.java
@@ -13,14 +13,14 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoGrass;
 import rtg.api.world.deco.DecoShrub;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 import static rtg.api.world.deco.DecoFallenTree.LogCondition.NOISE_GREATER_AND_RANDOM_CHANCE;
 
 public class RealisticBiomeBYGBirchPlains extends RealisticBiomeBYGBase {
@@ -64,7 +64,7 @@ public class RealisticBiomeBYGBirchPlains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 80f, 65f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -104,10 +104,10 @@ public class RealisticBiomeBYGBirchPlains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGFrozenTundra.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGFrozenTundra.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -47,9 +47,9 @@ public class RealisticBiomeBYGFrozenTundra extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
             //return terrainMountainRiver(x, y, simplex, cell, river, 300f, 67f);
         }
     }
@@ -68,10 +68,10 @@ public class RealisticBiomeBYGFrozenTundra extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGLushForest.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGLushForest.java
@@ -13,14 +13,14 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoGrass;
 import rtg.api.world.deco.DecoShrub;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 import static rtg.api.world.deco.DecoFallenTree.LogCondition.NOISE_GREATER_AND_RANDOM_CHANCE;
 
 public class RealisticBiomeBYGLushForest extends RealisticBiomeBYGBase {
@@ -64,7 +64,7 @@ public class RealisticBiomeBYGLushForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 80f, 65f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -104,10 +104,10 @@ public class RealisticBiomeBYGLushForest extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGMushroomMountains.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGMushroomMountains.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -62,25 +62,25 @@ public class RealisticBiomeBYGMushroomMountains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            rtgWorld.simplex.riverJitter().evaluateNoise((float)x / wavelength, (float)y / wavelength, jitter);
+            rtgWorld.simplex().riverJitter().evaluateNoise((float)x / wavelength, (float)y / wavelength, jitter);
             float pX = (float)((float)x + jitter.deltax() * amplitude);
             float pY = (float)((float)y + jitter.deltay() * amplitude);
 
-            float h = rtgWorld.simplex.noise2(pX / 19f, pY / 19f);
+            float h = rtgWorld.simplex().noise2(pX / 19f, pY / 19f);
             h = h*h*2f;
-            float h2 = rtgWorld.simplex.noise2(pX / 13f, pY / 13f);
+            float h2 = rtgWorld.simplex().noise2(pX / 13f, pY / 13f);
             h2 = h2 * h2 * 1.3f;
             h = Math.max(h, h2);
             h += h2;
-            float h3 = rtgWorld.simplex.noise2( pX / 53f, pY /53f);
+            float h3 = rtgWorld.simplex().noise2( pX / 53f, pY /53f);
             h3= h3*h3*5f;
             h+= h3;
 
-            float m = unsignedPower(rtgWorld.simplex.noise2(pX / width, pY / width),1.4f) * strength * river;
+            float m = unsignedPower(rtgWorld.simplex().noise2(pX / width, pY / width),1.4f) * strength * river;
             // invert y and x for complexity
-            float m2 = unsignedPower(rtgWorld.simplex.noise2(pY / (width*1.5f), pX / (width*1.5f)),1.4f) * strength * river;
+            float m2 = unsignedPower(rtgWorld.simplex().noise2(pY / (width*1.5f), pX / (width*1.5f)),1.4f) * strength * river;
 
             m = Math.max(m, m2);
 
@@ -128,10 +128,10 @@ public class RealisticBiomeBYGMushroomMountains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedDesert.java
@@ -12,11 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeBYGRedDesert extends RealisticBiomeBYGBase {
 
@@ -49,19 +50,19 @@ public class RealisticBiomeBYGRedDesert extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPolar(x, y, simplex, river);
             float duneHeight = (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get());
 
-            duneHeight *= (1f + rtgWorld.simplex.octave(2).noise2((float) x / 330f, (float) y / 330f)) / 2f;
+            duneHeight *= (1f + rtgWorld.simplex().octave(2).noise2((float) x / 330f, (float) y / 330f)) / 2f;
 
             float stPitch = 200f;    // The higher this is, the more smoothly dunes blend with the terrain
             float stFactor = duneHeight;
             float hPitch = 70;    // Dune scale
             float hDivisor = 40;
 
-            return terrainPolar(x, y, rtgWorld.simplex, river, stPitch, stFactor, hPitch, hDivisor, base) +
-                groundNoise(x, y, 1f, rtgWorld.simplex);
+            return terrainPolar(x, y, rtgWorld.simplex(), river, stPitch, stFactor, hPitch, hDivisor, base) +
+                groundNoise(x, y, 1f, rtgWorld.simplex());
         }
     }
 
@@ -99,10 +100,10 @@ public class RealisticBiomeBYGRedDesert extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedDesert.java
@@ -17,7 +17,6 @@ import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeBYGRedDesert extends RealisticBiomeBYGBase {
 
@@ -173,7 +172,7 @@ public class RealisticBiomeBYGRedDesert extends RealisticBiomeBYGBase {
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedRockMountains.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGRedRockMountains.java
@@ -14,7 +14,7 @@ import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -63,25 +63,25 @@ public class RealisticBiomeBYGRedRockMountains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            rtgWorld.simplex.riverJitter().evaluateNoise((float)x / wavelength, (float)y / wavelength, jitter);
+            rtgWorld.simplex().riverJitter().evaluateNoise((float)x / wavelength, (float)y / wavelength, jitter);
             float pX = (float)((float)x + jitter.deltax() * amplitude);
             float pY = (float)((float)y + jitter.deltay() * amplitude);
 
-            float h = rtgWorld.simplex.noise2(pX / 19f, pY / 19f);
+            float h = rtgWorld.simplex().noise2(pX / 19f, pY / 19f);
             h = h*h*2f;
-            float h2 = rtgWorld.simplex.noise2(pX / 13f, pY / 13f);
+            float h2 = rtgWorld.simplex().noise2(pX / 13f, pY / 13f);
             h2 = h2 * h2 * 1.3f;
             h = Math.max(h, h2);
             h += h2;
-            float h3 = rtgWorld.simplex.noise2( pX / 53f, pY /53f);
+            float h3 = rtgWorld.simplex().noise2( pX / 53f, pY /53f);
             h3= h3*h3*5f;
             h+= h3;
 
-            float m = unsignedPower(rtgWorld.simplex.noise2(pX / width, pY / width),1.4f) * strength * river;
+            float m = unsignedPower(rtgWorld.simplex().noise2(pX / width, pY / width),1.4f) * strength * river;
             // invert y and x for complexity
-            float m2 = unsignedPower(rtgWorld.simplex.noise2(pY / (width*1.5f), pX / (width*1.5f)),1.4f) * strength * river;
+            float m2 = unsignedPower(rtgWorld.simplex().noise2(pY / (width*1.5f), pX / (width*1.5f)),1.4f) * strength * river;
 
             m = Math.max(m, m2);
 
@@ -133,10 +133,10 @@ public class RealisticBiomeBYGRedRockMountains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 
@@ -213,19 +213,19 @@ public class RealisticBiomeBYGRedRockMountains extends RealisticBiomeBYGBase {
         }
 
         @Override
-        protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
             //return redRockStone;
             return Blocks.STONE.getDefaultState();
         }
 
         @Override
-        protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+        protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
             //return redRockCobble;
             return Blocks.COBBLESTONE.getDefaultState();
         }
 
         @Override
-        protected IBlockState getShadowStoneBlock(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState getShadowStoneBlock(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
             //return redClay;
             return redRockStone;
         }

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGShrubs.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGShrubs.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -60,11 +60,11 @@ public class RealisticBiomeBYGShrubs extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -110,10 +110,10 @@ public class RealisticBiomeBYGShrubs extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGWillowSwamps.java
+++ b/src/main/java/rtg/world/biome/realistic/biomesyougo/RealisticBiomeBYGWillowSwamps.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.deco.DecoShrub;
@@ -56,9 +56,9 @@ public class RealisticBiomeBYGWillowSwamps extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -76,10 +76,10 @@ public class RealisticBiomeBYGWillowSwamps extends RealisticBiomeBYGBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/floricraft/RealisticBiomeFLORIRoseLand.java
+++ b/src/main/java/rtg/world/biome/realistic/floricraft/RealisticBiomeFLORIRoseLand.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,7 +45,7 @@ public class RealisticBiomeFLORIRoseLand extends RealisticBiomeFLORIBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeFLORIRoseLand extends RealisticBiomeFLORIBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/floricraft/RealisticBiomeFLORITulipLand.java
+++ b/src/main/java/rtg/world/biome/realistic/floricraft/RealisticBiomeFLORITulipLand.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -45,7 +45,7 @@ public class RealisticBiomeFLORITulipLand extends RealisticBiomeFLORIBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeFLORITulipLand extends RealisticBiomeFLORIBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/flowercraft/RealisticBiomeFCPhantasia.java
+++ b/src/main/java/rtg/world/biome/realistic/flowercraft/RealisticBiomeFCPhantasia.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeFCPhantasia extends RealisticBiomeFCBase {
 
@@ -45,7 +45,7 @@ public class RealisticBiomeFCPhantasia extends RealisticBiomeFCBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeFCPhantasia extends RealisticBiomeFCBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/iceandfire/RealisticBiomeIAFGlacier.java
+++ b/src/main/java/rtg/world/biome/realistic/iceandfire/RealisticBiomeIAFGlacier.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.Bayesian;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -118,7 +118,7 @@ public class RealisticBiomeIAFGlacier extends RealisticBiomeIAFBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             // ground effect is increased by the multiplier
             float groundEffectLevel = groundEffect.added(rtgWorld, (float)x, (float)y);
             float ridging = multiplier.added(rtgWorld, (float)x, (float )y);
@@ -164,10 +164,10 @@ public class RealisticBiomeIAFGlacier extends RealisticBiomeIAFBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/jikou/RealisticBiomeJIKCherry.java
+++ b/src/main/java/rtg/world/biome/realistic/jikou/RealisticBiomeJIKCherry.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -47,11 +47,11 @@ public class RealisticBiomeJIKCherry extends RealisticBiomeJIKBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            float h = terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 65f);
 
             return riverized(groundNoise + h, river);
         }
@@ -91,10 +91,10 @@ public class RealisticBiomeJIKCherry extends RealisticBiomeJIKBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/jikou/RealisticBiomeJIKJikou.java
+++ b/src/main/java/rtg/world/biome/realistic/jikou/RealisticBiomeJIKJikou.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -48,9 +48,9 @@ public class RealisticBiomeJIKJikou extends RealisticBiomeJIKBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainSwampMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, width, heigth, 140f, 39f, 65f);
+            return terrainSwampMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, width, heigth, 140f, 39f, 65f);
         }
     }
 
@@ -86,10 +86,10 @@ public class RealisticBiomeJIKJikou extends RealisticBiomeJIKBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWAppleForest.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWAppleForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -59,9 +59,9 @@ public class RealisticBiomeMWAppleForest extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, groundNoiseAmplitudeHills, 0f);
         }
     }
 
@@ -105,10 +105,10 @@ public class RealisticBiomeMWAppleForest extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWArctic.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWArctic.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeMWArctic extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            float result = terrainPlains(x, y, rtgWorld.simplex, river, ruggednessWavelength, ruggedness, heightPitch, heightDivisor, base);
+            float result = terrainPlains(x, y, rtgWorld.simplex(), river, ruggednessWavelength, ruggedness, heightPitch, heightDivisor, base);
             // no indentations; cutoff is not noticeable with these low slopes
             return result > base ? result : base;
         }
@@ -99,10 +99,10 @@ public class RealisticBiomeMWArctic extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;
@@ -156,13 +156,13 @@ public class RealisticBiomeMWArctic extends RealisticBiomeMWBase {
         }
 
         @Override
-        protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
             return topBlock;
         }
 
         @Override
-        protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+        protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
 
             return topBlock;
         }

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWDeadForest.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWDeadForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBase;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoBoulder;
@@ -67,9 +67,9 @@ public class RealisticBiomeMWDeadForest extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainRollingHills(x, y, rtgWorld.simplex, river, hillStrength, maxHeight, groundNoise, deadForestGroundAmplitude, 0f);
+            return terrainRollingHills(x, y, rtgWorld.simplex(), river, hillStrength, maxHeight, groundNoise, deadForestGroundAmplitude, 0f);
         }
     }
 
@@ -113,10 +113,10 @@ public class RealisticBiomeMWDeadForest extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWIceHills.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWIceHills.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -55,9 +55,9 @@ public class RealisticBiomeMWIceHills extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, terrainHeight);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, terrainHeight);
         }
     }
 
@@ -103,10 +103,10 @@ public class RealisticBiomeMWIceHills extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWPalms.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWPalms.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -46,9 +46,9 @@ public class RealisticBiomeMWPalms extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 160f, 30f, 65f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 160f, 30f, 65f);
         }
     }
 
@@ -92,10 +92,10 @@ public class RealisticBiomeMWPalms extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWVolcano.java
+++ b/src/main/java/rtg/world/biome/realistic/mineworld/RealisticBiomeMWVolcano.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -52,9 +52,9 @@ public class RealisticBiomeMWVolcano extends RealisticBiomeMWBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainVolcano(x, y, rtgWorld.simplex, rtgWorld.cell, border, 70f);
+            return terrainVolcano(x, y, rtgWorld.simplex(), rtgWorld.cell(), border, 70f);
         }
     }
 
@@ -99,10 +99,10 @@ public class RealisticBiomeMWVolcano extends RealisticBiomeMWBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;
@@ -156,13 +156,13 @@ public class RealisticBiomeMWVolcano extends RealisticBiomeMWBase {
         }
 
         @Override
-        protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
 
             return lavaRock;
         }
 
         @Override
-        protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+        protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
 
             return lavaRock;
         }

--- a/src/main/java/rtg/world/biome/realistic/mithwoodforest/RealisticBiomeMFMithwoodForest.java
+++ b/src/main/java/rtg/world/biome/realistic/mithwoodforest/RealisticBiomeMFMithwoodForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.helper.DecoHelper5050;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
@@ -59,11 +59,11 @@ public class RealisticBiomeMFMithwoodForest extends RealisticBiomeMFBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            float h = terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 65f);
 
             return riverized(groundNoise + h, river);
         }
@@ -103,10 +103,10 @@ public class RealisticBiomeMFMithwoodForest extends RealisticBiomeMFBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMBlackPlain.java
+++ b/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMBlackPlain.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeMCMBlackPlain extends RealisticBiomeMCMBase {
 
@@ -45,7 +45,7 @@ public class RealisticBiomeMCMBlackPlain extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -65,10 +65,10 @@ public class RealisticBiomeMCMBlackPlain extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMBog.java
+++ b/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMBog.java
@@ -12,12 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightVariation;
 import rtg.api.world.terrain.heighteffect.HillockEffect;
-import rtg.api.world.terrain.TerrainBase;
 
 public class RealisticBiomeMCMBog extends RealisticBiomeMCMBase {
 
@@ -67,7 +67,7 @@ public class RealisticBiomeMCMBog extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             float increment = bottomVariation.added(rtgWorld, x, y) + smallHills.added(rtgWorld, x, y);
             increment += mediumHills.added(rtgWorld, x, y);
@@ -89,10 +89,10 @@ public class RealisticBiomeMCMBog extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMLoessPlateau.java
+++ b/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMLoessPlateau.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -93,9 +93,9 @@ public class RealisticBiomeMCMLoessPlateau extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainCanyon(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, booRiver);
+            return terrainCanyon(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, booRiver);
         }
     }
 
@@ -141,10 +141,10 @@ public class RealisticBiomeMCMLoessPlateau extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMMudFlat.java
+++ b/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMMudFlat.java
@@ -12,12 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightVariation;
 import rtg.api.world.terrain.heighteffect.HillockEffect;
-import rtg.api.world.terrain.TerrainBase;
 
 public class RealisticBiomeMCMMudFlat extends RealisticBiomeMCMBase {
 
@@ -67,7 +67,7 @@ public class RealisticBiomeMCMMudFlat extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             float increment = bottomVariation.added(rtgWorld, x, y) + smallHills.added(rtgWorld, x, y);
             increment += mediumHills.added(rtgWorld, x, y);
@@ -89,10 +89,10 @@ public class RealisticBiomeMCMMudFlat extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMWarmTaiga.java
+++ b/src/main/java/rtg/world/biome/realistic/morechinesemc/RealisticBiomeMCMWarmTaiga.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.deco.DecoFallenTree;
@@ -60,11 +60,11 @@ public class RealisticBiomeMCMWarmTaiga extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -110,10 +110,10 @@ public class RealisticBiomeMCMWarmTaiga extends RealisticBiomeMCMBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/rockhoundingsurface/RealisticBiomeRHSWhiteSands.java
+++ b/src/main/java/rtg/world/biome/realistic/rockhoundingsurface/RealisticBiomeRHSWhiteSands.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -52,7 +52,7 @@ public class RealisticBiomeRHSWhiteSands extends RealisticBiomeRHSBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -92,10 +92,10 @@ public class RealisticBiomeRHSWhiteSands extends RealisticBiomeRHSBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;
@@ -164,22 +164,22 @@ public class RealisticBiomeRHSWhiteSands extends RealisticBiomeRHSBase {
         }
 
         @Override
-        protected IBlockState hcStone(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState hcStone(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
             return whiteSandBlock;
         }
 
         @Override
-        protected IBlockState hcCobble(RTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
+        protected IBlockState hcCobble(IRTGWorld rtgWorld, int worldX, int worldZ, int chunkX, int chunkZ, int worldY) {
             return whiteSandBlock;
         }
 
         @Override
-        protected IBlockState getShadowStoneBlock(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState getShadowStoneBlock(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
             return whiteSandBlock;
         }
 
         @Override
-        protected IBlockState getShadowDesertBlock(RTGWorld rtgWorld, int i, int j, int x, int y, int k) {
+        protected IBlockState getShadowDesertBlock(IRTGWorld rtgWorld, int i, int j, int x, int y, int k) {
             return whiteSandBlock;
         }
     }

--- a/src/main/java/rtg/world/biome/realistic/sugiforest/RealisticBiomeSFSugiForest.java
+++ b/src/main/java/rtg/world/biome/realistic/sugiforest/RealisticBiomeSFSugiForest.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -56,11 +56,11 @@ public class RealisticBiomeSFSugiForest extends RealisticBiomeSFBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundNoiseAmplitudeHills, rtgWorld.simplex());
 
-            float h = terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
+            float h = terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, peakyHillWavelength, peakyHillStrength, smoothHillWavelength, smoothHillStrength, baseHeight);
 
             return riverized(groundNoise + h, river);
         }
@@ -106,10 +106,10 @@ public class RealisticBiomeSFSugiForest extends RealisticBiomeSFBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/vampirism/RealisticBiomeVAMPVampireForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vampirism/RealisticBiomeVAMPVampireForest.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,7 +50,7 @@ public class RealisticBiomeVAMPVampireForest extends RealisticBiomeVAMPBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -70,10 +70,10 @@ public class RealisticBiomeVAMPVampireForest extends RealisticBiomeVAMPBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBeach.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoTree;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGCocosNucifera;
@@ -50,9 +50,9 @@ public class RealisticBiomeVanillaBeach extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 63f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 63f);
         }
     }
 
@@ -81,9 +81,9 @@ public class RealisticBiomeVanillaBeach extends RealisticBiomeVanillaBase {
 
         @SuppressWarnings("unused")
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f ? true : false;
             boolean dirt = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForest.java
@@ -13,11 +13,11 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionBirchForest;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase {
 
@@ -55,7 +55,7 @@ public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 80f, 65f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -95,10 +95,10 @@ public class RealisticBiomeVanillaBirchForest extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHills.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionBirchForest;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -60,9 +60,9 @@ public class RealisticBiomeVanillaBirchForestHills extends RealisticBiomeVanilla
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
         }
     }
 
@@ -100,10 +100,10 @@ public class RealisticBiomeVanillaBirchForestHills extends RealisticBiomeVanilla
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestHillsM.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionBirchForest;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeVanillaBirchForestHillsM extends RealisticBiomeVanill
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, 10f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, 10f);
         }
     }
 
@@ -70,9 +70,9 @@ public class RealisticBiomeVanillaBirchForestHillsM extends RealisticBiomeVanill
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaBirchForestM.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGBetulaPapyrifera;
@@ -55,9 +55,9 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 65f);
         }
     }
 
@@ -95,10 +95,10 @@ public class RealisticBiomeVanillaBirchForestM extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdBeach.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBoulder;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -47,9 +47,9 @@ public class RealisticBiomeVanillaColdBeach extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 63f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 63f);
         }
     }
 
@@ -77,10 +77,10 @@ public class RealisticBiomeVanillaColdBeach extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f ? true : false;
             boolean dirt = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaiga.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaiga.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -47,9 +47,9 @@ public class RealisticBiomeVanillaColdTaiga extends RealisticBiomeVanillaBase {
 
         }
 
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 13f, 66f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 13f, 66f);
         }
     }
 
@@ -66,10 +66,10 @@ public class RealisticBiomeVanillaColdTaiga extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaHills.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeVanillaColdTaigaHills extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, 35f, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, 35f, base - 62f);
         }
     }
 
@@ -95,10 +95,10 @@ public class RealisticBiomeVanillaColdTaigaHills extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaColdTaigaM.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -48,9 +48,9 @@ public class RealisticBiomeVanillaColdTaigaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 80f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 4f, 80f, 68f);
         }
     }
 
@@ -68,9 +68,9 @@ public class RealisticBiomeVanillaColdTaigaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDeepOcean.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDeepOcean.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoSponge;
 import rtg.api.world.surface.SurfaceBase;
@@ -53,9 +53,9 @@ public class RealisticBiomeVanillaDeepOcean extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOcean(x, y, rtgWorld.simplex, river, 40f);
+            return terrainOcean(x, y, rtgWorld.simplex(), river, 40f);
         }
     }
 
@@ -83,10 +83,10 @@ public class RealisticBiomeVanillaDeepOcean extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             for (int k = 255; k > -1; k--) {
                 Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesert.java
@@ -16,7 +16,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesert extends RealisticBiomeVanillaBase {
 
@@ -75,7 +74,7 @@ public class RealisticBiomeVanillaDesert extends RealisticBiomeVanillaBase {
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesert.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesert.java
@@ -11,11 +11,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesert extends RealisticBiomeVanillaBase {
 
@@ -51,19 +52,19 @@ public class RealisticBiomeVanillaDesert extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPolar(x, y, simplex, river);
             float duneHeight = (minDuneHeight + (float) rtgConfig.DUNE_HEIGHT.get());
 
-            duneHeight *= (1f + rtgWorld.simplex.octave(2).noise2((float) x / 330f, (float) y / 330f)) / 2f;
+            duneHeight *= (1f + rtgWorld.simplex().octave(2).noise2((float) x / 330f, (float) y / 330f)) / 2f;
 
             float stPitch = 200f;    // The higher this is, the more smoothly dunes blend with the terrain
             float stFactor = duneHeight;
             float hPitch = 70;    // Dune scale
             float hDivisor = 40;
 
-            return terrainPolar(x, y, rtgWorld.simplex, river, stPitch, stFactor, hPitch, hDivisor, base) +
-                groundNoise(x, y, 1f, rtgWorld.simplex);
+            return terrainPolar(x, y, rtgWorld.simplex(), river, stPitch, stFactor, hPitch, hDivisor, base) +
+                groundNoise(x, y, 1f, rtgWorld.simplex());
         }
     }
 
@@ -92,10 +93,10 @@ public class RealisticBiomeVanillaDesert extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             boolean water = false;
             boolean riverPaint = false;
             boolean grass = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
@@ -12,11 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase {
 
@@ -57,8 +58,8 @@ public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
         }
     }
 
@@ -105,10 +106,10 @@ public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertHills.java
@@ -17,7 +17,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase {
 
@@ -70,7 +69,7 @@ public class RealisticBiomeVanillaDesertHills extends RealisticBiomeVanillaBase 
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
@@ -12,11 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
 
@@ -57,9 +58,9 @@ public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, 10f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, 10f);
         }
     }
 
@@ -106,10 +107,10 @@ public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaDesertM.java
@@ -17,7 +17,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesert;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
 
@@ -71,7 +70,7 @@ public class RealisticBiomeVanillaDesertM extends RealisticBiomeVanillaBase {
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHills.java
@@ -13,17 +13,12 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.Bayesian;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
-import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.TerrainBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
-import rtg.api.world.terrain.heighteffect.HeightEffect;
-import rtg.api.world.terrain.heighteffect.JitterEffect;
-import rtg.api.world.terrain.heighteffect.RaiseEffect;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHills;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHillsCommon;
-import rtg.api.world.terrain.heighteffect.SpikeEverywhereEffect;
-import rtg.api.world.terrain.heighteffect.VoronoiBorderEffect;
+import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.*;
 
 public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase {
 
@@ -129,7 +124,7 @@ public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase
         }
         
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
              // ground effect is increased by the multiplier
             float groundEffectLevel = groundEffect.added(rtgWorld, (float)x, (float)y);
             float ridging = multiplier.added(rtgWorld, (float)x, (float )y);
@@ -155,9 +150,9 @@ public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base);
         }
     }
 
@@ -191,10 +186,10 @@ public class RealisticBiomeVanillaExtremeHills extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsEdge.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGPinusNigra;
@@ -68,9 +68,9 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, 10f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, 10f);
         }
     }
 
@@ -104,10 +104,10 @@ public class RealisticBiomeVanillaExtremeHillsEdge extends RealisticBiomeVanilla
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsM.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
-import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHillsCommon;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHillsM;
+import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
 
 public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBase {
 
@@ -61,9 +61,9 @@ public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, start, width, height, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, start, width, height, base - 62f);
         }
     }
 
@@ -97,10 +97,10 @@ public class RealisticBiomeVanillaExtremeHillsM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlus.java
@@ -12,14 +12,14 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
+import rtg.api.world.deco.collection.DecoCollectionExtremeHillsCommon;
+import rtg.api.world.deco.collection.DecoCollectionExtremeHillsPlus;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.HeightEffect;
 import rtg.api.world.terrain.heighteffect.JitterEffect;
 import rtg.api.world.terrain.heighteffect.MountainsWithPassesEffect;
-import rtg.api.world.deco.collection.DecoCollectionExtremeHillsCommon;
-import rtg.api.world.deco.collection.DecoCollectionExtremeHillsPlus;
 
 public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanillaBase {
 
@@ -75,7 +75,7 @@ public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanilla
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(heightEffect.added(rtgWorld, x, y) + base, river);
         }
@@ -115,10 +115,10 @@ public class RealisticBiomeVanillaExtremeHillsPlus extends RealisticBiomeVanilla
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaExtremeHillsPlusM.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
-import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHillsCommon;
 import rtg.api.world.deco.collection.DecoCollectionExtremeHillsPlusM;
+import rtg.api.world.surface.SurfaceBase;
+import rtg.api.world.terrain.TerrainBase;
 
 public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanillaBase {
 
@@ -58,9 +58,9 @@ public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanill
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, base);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, base);
         }
     }
 
@@ -98,10 +98,10 @@ public class RealisticBiomeVanillaExtremeHillsPlusM extends RealisticBiomeVanill
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFlowerForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFlowerForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionSmallPineTreesForest;
 import rtg.api.world.deco.helper.DecoHelper5050;
@@ -56,9 +56,9 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 80f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 80f, 65f);
         }
     }
 
@@ -96,10 +96,10 @@ public class RealisticBiomeVanillaFlowerForest extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionForest;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -53,11 +53,11 @@ public class RealisticBiomeVanillaForest extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex);
+            groundNoise = groundNoise(x, y, groundVariation, rtgWorld.simplex());
 
-            float m = hills(x, y, hillStrength, rtgWorld.simplex, river);
+            float m = hills(x, y, hillStrength, rtgWorld.simplex(), river);
 
             float floNoise = 65f + groundNoise + m;
 
@@ -99,10 +99,10 @@ public class RealisticBiomeVanillaForest extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForestHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaForestHills.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionForest;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -61,9 +61,9 @@ public class RealisticBiomeVanillaForestHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
 
         }
     }
@@ -102,10 +102,10 @@ public class RealisticBiomeVanillaForestHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenOcean.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenOcean.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeVanillaFrozenOcean extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOcean(x, y, rtgWorld.simplex, river, 50f);
+            return terrainOcean(x, y, rtgWorld.simplex(), river, 50f);
         }
     }
 
@@ -81,10 +81,10 @@ public class RealisticBiomeVanillaFrozenOcean extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             for (int k = 255; k > -1; k--) {
                 Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenRiver.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaFrozenRiver.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -44,9 +44,9 @@ public class RealisticBiomeVanillaFrozenRiver extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 3f, 60f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 3f, 60f);
         }
     }
 
@@ -64,10 +64,10 @@ public class RealisticBiomeVanillaFrozenRiver extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             if (river > 0.05f && river + (simplex.noise2(i / 10f, j / 10f) * 0.15f) > 0.8f) {
                 Block b;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIceMountains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIceMountains.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -59,9 +59,9 @@ public class RealisticBiomeVanillaIceMountains extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, terrainHeight);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, terrainHeight);
         }
     }
 
@@ -114,10 +114,10 @@ public class RealisticBiomeVanillaIceMountains extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
             boolean mix = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIcePlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIcePlains.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.SnowHeightCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -49,9 +49,9 @@ public class RealisticBiomeVanillaIcePlains extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-			return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 65f);
+			return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 65f);
         }
     }
 
@@ -92,9 +92,9 @@ public class RealisticBiomeVanillaIcePlains extends RealisticBiomeVanillaBase {
 		}
 
 		@Override
-		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-			Random rand = rtgWorld.rand;
+			Random rand = rtgWorld.rand();
 			float c = CliffCalculator.calc(x, z, noise);
 			boolean cliff = c > 1.4f ? true : false;
 
@@ -157,10 +157,10 @@ public class RealisticBiomeVanillaIcePlains extends RealisticBiomeVanillaBase {
 		}
 
 		@Override
-		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+		public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-			Random rand = rtgWorld.rand;
-			OpenSimplexNoise simplex = rtgWorld.simplex;
+			Random rand = rtgWorld.rand();
+			OpenSimplexNoise simplex = rtgWorld.simplex();
 			boolean water = false;
 			boolean riverPaint = false;
 			boolean grass = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIcePlainsSpikes.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaIcePlainsSpikes.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.collection.DecoCollectionIceTrees;
 import rtg.api.world.surface.SurfaceBase;
@@ -48,9 +48,9 @@ public class RealisticBiomeVanillaIcePlainsSpikes extends RealisticBiomeVanillaB
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlains(x, y, rtgWorld.simplex, river, 160f, 10f, 60f, 200f, 65f);
+            return terrainPlains(x, y, rtgWorld.simplex(), river, 160f, 10f, 60f, 200f, 65f);
         }
     }
 
@@ -74,9 +74,9 @@ public class RealisticBiomeVanillaIcePlainsSpikes extends RealisticBiomeVanillaB
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungle.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungle.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionJungle;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -54,9 +54,9 @@ public class RealisticBiomeVanillaJungle extends RealisticBiomeVanillaBase {
 
         }
 
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 3f, 66f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 3f, 66f);
         }
     }
 
@@ -95,10 +95,10 @@ public class RealisticBiomeVanillaJungle extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleEdge.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleEdge.java
@@ -12,12 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 import static rtg.api.world.deco.DecoFallenTree.LogCondition.NOISE_GREATER_AND_RANDOM_CHANCE;
 
 public class RealisticBiomeVanillaJungleEdge extends RealisticBiomeVanillaBase {
@@ -55,7 +55,7 @@ public class RealisticBiomeVanillaJungleEdge extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -75,9 +75,9 @@ public class RealisticBiomeVanillaJungleEdge extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleEdgeM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleEdgeM.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -52,9 +52,9 @@ public class RealisticBiomeVanillaJungleEdgeM extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 80f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 4f, 80f, 68f);
         }
     }
 
@@ -72,9 +72,9 @@ public class RealisticBiomeVanillaJungleEdgeM extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleHills.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionJungle;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -56,9 +56,9 @@ public class RealisticBiomeVanillaJungleHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
         }
     }
 
@@ -95,10 +95,10 @@ public class RealisticBiomeVanillaJungleHills extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaJungleM.java
@@ -11,7 +11,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionJungle;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeVanillaJungleM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 80f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 4f, 80f, 68f);
         }
     }
 
@@ -71,9 +71,9 @@ public class RealisticBiomeVanillaJungleM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaSpruceTaiga.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaSpruceTaiga.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.deco.DecoFallenTree;
 import rtg.api.world.surface.SurfaceBase;
@@ -53,9 +53,9 @@ public class RealisticBiomeVanillaMegaSpruceTaiga extends RealisticBiomeVanillaB
 
         }
 
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 14f, 66f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 14f, 66f);
         }
     }
 
@@ -73,10 +73,10 @@ public class RealisticBiomeVanillaMegaSpruceTaiga extends RealisticBiomeVanillaB
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaTaiga.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaTaiga.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionMegaTaiga;
 import rtg.api.world.surface.SurfaceBase;
@@ -52,9 +52,9 @@ public class RealisticBiomeVanillaMegaTaiga extends RealisticBiomeVanillaBase {
 
         }
 
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 13f, 66f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 13f, 66f);
         }
     }
 
@@ -72,10 +72,10 @@ public class RealisticBiomeVanillaMegaTaiga extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaTaigaHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMegaTaigaHills.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionMegaTaiga;
 import rtg.api.world.surface.SurfaceBase;
@@ -57,9 +57,9 @@ public class RealisticBiomeVanillaMegaTaigaHills extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
         }
     }
 
@@ -102,10 +102,10 @@ public class RealisticBiomeVanillaMegaTaigaHills extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesa.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesa.java
@@ -12,12 +12,13 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.GroundEffect;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
 
@@ -53,7 +54,7 @@ public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             return riverized(68f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -97,9 +98,9 @@ public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -115,7 +116,7 @@ public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesa.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesa.java
@@ -18,7 +18,6 @@ import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.GroundEffect;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
 
@@ -67,7 +66,7 @@ public class RealisticBiomeVanillaMesa extends RealisticBiomeVanillaBase {
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaBryce.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaBryce.java
@@ -20,7 +20,6 @@ import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.VoronoiBasinEffect;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
 
@@ -142,7 +141,7 @@ public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaBryce.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaBryce.java
@@ -14,12 +14,13 @@ import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.PlateauStep;
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.VoronoiBasinEffect;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
 
@@ -73,19 +74,19 @@ public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
 
          
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int passedX, int passedY, float border, float river) {
-            rtgWorld.simplex.riverJitter().evaluateNoise((float) passedX / jitterWavelength, (float) passedY / jitterWavelength, jitter);
-        float x = (float)(passedX + jitter.deltax() * jitterAmplitude);
-        float y = (float)(passedY + jitter.deltay() * jitterAmplitude);
+        public float generateNoise(IRTGWorld rtgWorld, int passedX, int passedY, float border, float river) {
+            rtgWorld.simplex().riverJitter().evaluateNoise((float) passedX / jitterWavelength, (float) passedY / jitterWavelength, jitter);
+            float x = (float)(passedX + jitter.deltax() * jitterAmplitude);
+            float y = (float)(passedY + jitter.deltay() * jitterAmplitude);
             float simplex = plateau.added(rtgWorld, x, y);
             simplex *= river;
-            float bumpiness = rtgWorld.simplex.octave(bumpinessOctave).noise2(x / bumpinessWavelength, y / bumpinessWavelength) * bumpinessMultiplier;
-            bumpiness += rtgWorld.simplex.octave(bumpinessOctave+1).noise2(x / bumpinessWavelength/2f, y / bumpinessWavelength/2f) * bumpinessMultiplier/2f;
-            
+            float bumpiness = rtgWorld.simplex().octave(bumpinessOctave).noise2(x / bumpinessWavelength, y / bumpinessWavelength) * bumpinessMultiplier;
+            bumpiness += rtgWorld.simplex().octave(bumpinessOctave+1).noise2(x / bumpinessWavelength/2f, y / bumpinessWavelength/2f) * bumpinessMultiplier/2f;
+
             simplex += bumpiness;
             //if (simplex > bordercap) simplex = bordercap;
             float added = step.increase(simplex);
-            return riverized(base + TerrainBase.groundNoise(x, y, groundNoise, rtgWorld.simplex),river) + added;
+            return riverized(base + TerrainBase.groundNoise(x, y, groundNoise, rtgWorld.simplex()),river) + added;
         }
         
     }
@@ -128,9 +129,9 @@ public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBryce(x, y, rtgWorld.simplex, river, height, border);
+            return terrainBryce(x, y, rtgWorld.simplex(), river, height, border);
         }
     }
 
@@ -172,9 +173,9 @@ public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -190,7 +191,7 @@ public class RealisticBiomeVanillaMesaBryce extends RealisticBiomeVanillaBase {
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateau.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateau.java
@@ -20,7 +20,6 @@ import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.VoronoiPlateauEffect;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase {
 
@@ -149,7 +148,7 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateau.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateau.java
@@ -14,12 +14,13 @@ import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.PlateauStep;
 import rtg.api.util.noise.SimplexOctave;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
 import rtg.api.world.terrain.heighteffect.VoronoiPlateauEffect;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase {
 
@@ -74,10 +75,10 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
 
          
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int passedX, int passedY, float border, float river) {
-            rtgWorld.simplex.riverJitter().evaluateNoise((float) passedX / jitterWavelength, (float) passedY / jitterWavelength, jitter);
-        float x = (float)(passedX + jitter.deltax() * jitterAmplitude);
-        float y = (float)(passedY + jitter.deltay() * jitterAmplitude);
+        public float generateNoise(IRTGWorld rtgWorld, int passedX, int passedY, float border, float river) {
+            rtgWorld.simplex().riverJitter().evaluateNoise((float) passedX / jitterWavelength, (float) passedY / jitterWavelength, jitter);
+            float x = (float)(passedX + jitter.deltax() * jitterAmplitude);
+            float y = (float)(passedY + jitter.deltay() * jitterAmplitude);
             float simplex = plateau.added(rtgWorld, x, y);
             //if (simplex > river) simplex = river;
             float bordercap = border *3.5f -2.5f;
@@ -85,11 +86,11 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
             float rivercap = 3f*river;
             if (rivercap > 1) rivercap = 1;
             simplex *= rivercap*bordercap;
-            float bumpiness = rtgWorld.simplex.octave(bumpinessOctave).noise2(x / bumpinessWavelength, y / bumpinessWavelength) * bumpinessMultiplier;
+            float bumpiness = rtgWorld.simplex().octave(bumpinessOctave).noise2(x / bumpinessWavelength, y / bumpinessWavelength) * bumpinessMultiplier;
             simplex += bumpiness;
             //if (simplex > bordercap) simplex = bordercap;
             float added = step.increase(simplex)/border;
-            return riverized(base + TerrainBase.groundNoise(x, y, groundNoise, rtgWorld.simplex),river) + added;
+            return riverized(base + TerrainBase.groundNoise(x, y, groundNoise, rtgWorld.simplex()),river) + added;
         }
         
     }
@@ -135,9 +136,9 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 100f, false);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 100f, false);
         }
     }
 
@@ -179,9 +180,9 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -197,7 +198,7 @@ public class RealisticBiomeVanillaMesaPlateau extends RealisticBiomeVanillaBase 
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauF.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauF.java
@@ -19,7 +19,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase {
 
@@ -105,7 +104,7 @@ public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauF.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauF.java
@@ -13,12 +13,13 @@ import net.minecraft.world.gen.feature.WorldGenTrees;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoTree;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase {
 
@@ -91,9 +92,9 @@ public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 100f, false);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 100f, false);
         }
     }
 
@@ -143,9 +144,9 @@ public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -161,11 +162,11 @@ public class RealisticBiomeVanillaMesaPlateauF extends RealisticBiomeVanillaBase
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 
-                        float mixNoise = rtgWorld.simplex.noise2(i / 12f, j / 12f);
+                        float mixNoise = rtgWorld.simplex().noise2(i / 12f, j / 12f);
 
                         if (k > 74 + grassRaise)
                         {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauFM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauFM.java
@@ -13,12 +13,13 @@ import net.minecraft.world.gen.feature.WorldGenTrees;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoTree;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBase {
 
@@ -93,9 +94,9 @@ public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 100f, false);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 100f, false);
         }
     }
 
@@ -145,9 +146,9 @@ public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -163,11 +164,11 @@ public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBas
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 
-                        float mixNoise = rtgWorld.simplex.noise2(i / 12f, j / 12f);
+                        float mixNoise = rtgWorld.simplex().noise2(i / 12f, j / 12f);
 
                         if (k > 74 + grassRaise)
                         {

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauFM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauFM.java
@@ -19,7 +19,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBase {
 
@@ -107,7 +106,7 @@ public class RealisticBiomeVanillaMesaPlateauFM extends RealisticBiomeVanillaBas
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauM.java
@@ -17,7 +17,6 @@ import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
-import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase {
 
@@ -101,7 +100,7 @@ public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase
     }
 
     @Override
-    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+    public void rReplace(ChunkPrimer primer, int i, int j, int x, int y, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
         this.rReplaceWithRiver(primer, i, j, x, y, depth, rtgWorld, noise, river, base);
     }

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMesaPlateauM.java
@@ -12,11 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionMesa;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.world.RTGWorld;
 
 public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase {
 
@@ -86,10 +87,10 @@ public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
             river *= 0.5f;
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 50f, true);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 50f, true);
         }
     }
 
@@ -131,9 +132,9 @@ public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;
@@ -149,7 +150,7 @@ public class RealisticBiomeVanillaMesaPlateauM extends RealisticBiomeVanillaBase
                     depth++;
 
                     if (cliff) {
-                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome.getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
+                        primer.setBlockState(x, k, z, rtgWorld.mesaBiome().getBand(i, k, j));//CanyonColour.MESA.getBlockForHeight(i, k, j));
                     }
                     else {
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMushroomIsland.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMushroomIsland.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -55,9 +55,9 @@ public class RealisticBiomeVanillaMushroomIsland extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandFlats(x, y, rtgWorld.simplex, river, 40f, 25f, 68f);
+            return terrainGrasslandFlats(x, y, rtgWorld.simplex(), river, 40f, 25f, 68f);
         }
     }
 
@@ -93,10 +93,10 @@ public class RealisticBiomeVanillaMushroomIsland extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMushroomIslandShore.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaMushroomIslandShore.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -52,9 +52,9 @@ public class RealisticBiomeVanillaMushroomIslandShore extends RealisticBiomeVani
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -90,10 +90,10 @@ public class RealisticBiomeVanillaMushroomIslandShore extends RealisticBiomeVani
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaOcean.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaOcean.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -51,9 +51,9 @@ public class RealisticBiomeVanillaOcean extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainOcean(x, y, rtgWorld.simplex, river, 50f);
+            return terrainOcean(x, y, rtgWorld.simplex(), river, 50f);
         }
     }
 
@@ -82,10 +82,10 @@ public class RealisticBiomeVanillaOcean extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             for (int k = 255; k > -1; k--) {
                 Block b = primer.getBlockState(x, k, z).getBlock();

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaPlains.java
@@ -12,14 +12,14 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.helper.DecoHelperThisOrThat;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGQuercusRobur;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
 
@@ -55,7 +55,7 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -75,9 +75,9 @@ public class RealisticBiomeVanillaPlains extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRedwoodTaigaHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRedwoodTaigaHills.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionMegaTaiga;
 import rtg.api.world.surface.SurfaceBase;
@@ -55,9 +55,9 @@ public class RealisticBiomeVanillaRedwoodTaigaHills extends RealisticBiomeVanill
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
         }
     }
 
@@ -100,10 +100,10 @@ public class RealisticBiomeVanillaRedwoodTaigaHills extends RealisticBiomeVanill
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRiver.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRiver.java
@@ -10,7 +10,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -44,9 +44,9 @@ public class RealisticBiomeVanillaRiver extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 3f, 60f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 3f, 60f);
         }
     }
 
@@ -64,10 +64,10 @@ public class RealisticBiomeVanillaRiver extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
 
             if (river > 0.05f && river + (simplex.noise2(i / 10f, j / 10f) * 0.15f) > 0.8f) {
                 Block b;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForest.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.helper.DecoHelperThisOrThat;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
@@ -21,8 +21,8 @@ import rtg.api.world.gen.feature.tree.rtg.TreeRTGCeibaPentandra;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGCeibaRosea;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGRhizophoraMucronata;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 import static rtg.api.world.deco.DecoFallenTree.LogCondition.NOISE_GREATER_AND_RANDOM_CHANCE;
 
 public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase {
@@ -61,7 +61,7 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 80f, 65f)
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -102,10 +102,10 @@ public class RealisticBiomeVanillaRoofedForest extends RealisticBiomeVanillaBase
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForestM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaRoofedForestM.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGRhizophoraMucronata;
@@ -54,9 +54,9 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 50f, 68f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 4f, 50f, 68f);
         }
     }
 
@@ -74,9 +74,9 @@ public class RealisticBiomeVanillaRoofedForestM extends RealisticBiomeVanillaBas
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavanna.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavanna.java
@@ -12,12 +12,12 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionSavanna;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeVanillaSavanna extends RealisticBiomeVanillaBase {
 
@@ -55,7 +55,7 @@ public class RealisticBiomeVanillaSavanna extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 100f, 66f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -89,10 +89,10 @@ public class RealisticBiomeVanillaSavanna extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaM.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.deco.collection.DecoCollectionSavanna;
 import rtg.api.world.surface.SurfaceBase;
@@ -54,9 +54,9 @@ public class RealisticBiomeVanillaSavannaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandMountains(x, y, rtgWorld.simplex, rtgWorld.cell, river, 4f, 90f, 67f);
+            return terrainGrasslandMountains(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 4f, 90f, 67f);
         }
     }
 
@@ -97,10 +97,10 @@ public class RealisticBiomeVanillaSavannaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
             boolean m = false;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateau.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateau.java
@@ -11,9 +11,9 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
-import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
 import rtg.api.util.CanyonColour;
+import rtg.api.util.CliffCalculator;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
@@ -91,9 +91,9 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 50f, true);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 50f, true);
         }
     }
 
@@ -119,9 +119,9 @@ public class RealisticBiomeVanillaSavannaPlateau extends RealisticBiomeVanillaBa
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateauM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSavannaPlateauM.java
@@ -11,9 +11,9 @@ import net.minecraft.world.chunk.ChunkPrimer;
 
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
-import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
 import rtg.api.util.CanyonColour;
+import rtg.api.util.CliffCalculator;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.deco.collection.DecoCollectionDesertRiver;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
@@ -84,9 +84,9 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainPlateau(x, y, rtgWorld.simplex, river, height, border, strength, heightLength, 50f, true);
+            return terrainPlateau(x, y, rtgWorld.simplex(), river, height, border, strength, heightLength, 50f, true);
         }
     }
 
@@ -112,9 +112,9 @@ public class RealisticBiomeVanillaSavannaPlateauM extends RealisticBiomeVanillaB
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.3f;
             Block b;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaStoneBeach.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -46,9 +46,9 @@ public class RealisticBiomeVanillaStoneBeach extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainBeach(x, y, rtgWorld.simplex, river, 180f, 35f, 63f);
+            return terrainBeach(x, y, rtgWorld.simplex(), river, 180f, 35f, 63f);
         }
     }
 
@@ -84,10 +84,10 @@ public class RealisticBiomeVanillaStoneBeach extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSunflowerPlains.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSunflowerPlains.java
@@ -12,11 +12,11 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.DecoBaseBiomeDecorations;
 import rtg.api.world.surface.SurfaceBase;
-import rtg.api.world.terrain.heighteffect.GroundEffect;
 import rtg.api.world.terrain.TerrainBase;
+import rtg.api.world.terrain.heighteffect.GroundEffect;
 
 public class RealisticBiomeVanillaSunflowerPlains extends RealisticBiomeVanillaBase {
 
@@ -46,7 +46,7 @@ public class RealisticBiomeVanillaSunflowerPlains extends RealisticBiomeVanillaB
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
             //return terrainPlains(x, y, simplex, river, 160f, 10f, 60f, 200f, 65f);
             return riverized(65f + groundEffect.added(rtgWorld, x, y), river);
         }
@@ -66,10 +66,10 @@ public class RealisticBiomeVanillaSunflowerPlains extends RealisticBiomeVanillaB
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwampland.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwampland.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGPinusPonderosa;
@@ -52,9 +52,9 @@ public class RealisticBiomeVanillaSwampland extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainMarsh(x, y, rtgWorld.simplex, 61.5f,river);
+            return terrainMarsh(x, y, rtgWorld.simplex(), 61.5f,river);
         }
     }
 
@@ -72,10 +72,10 @@ public class RealisticBiomeVanillaSwampland extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwamplandM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaSwamplandM.java
@@ -12,7 +12,7 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.*;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTG;
 import rtg.api.world.gen.feature.tree.rtg.TreeRTGPinusPonderosa;
@@ -57,9 +57,9 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainLonelyMountain(x, y, rtgWorld.simplex, rtgWorld.cell, river, strength, width, terrainHeight);
+            return terrainLonelyMountain(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, strength, width, terrainHeight);
         }
     }
 
@@ -77,9 +77,9 @@ public class RealisticBiomeVanillaSwamplandM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
+            Random rand = rtgWorld.rand();
             float c = CliffCalculator.calc(x, z, noise);
             boolean cliff = c > 1.4f ? true : false;
 

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaiga.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaiga.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -50,9 +50,9 @@ public class RealisticBiomeVanillaTaiga extends RealisticBiomeVanillaBase {
 
         }
 
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainFlatLakes(x, y, rtgWorld.simplex, river, 8f, 68f);
+            return terrainFlatLakes(x, y, rtgWorld.simplex(), river, 8f, 68f);
         }
     }
 
@@ -74,10 +74,10 @@ public class RealisticBiomeVanillaTaiga extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaHills.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaHills.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -61,9 +61,9 @@ public class RealisticBiomeVanillaTaigaHills extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainHighland(x, y, rtgWorld.simplex, rtgWorld.cell, river, 10f, 68f, hillStrength, base - 62f);
+            return terrainHighland(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, 10f, 68f, hillStrength, base - 62f);
         }
     }
 
@@ -85,10 +85,10 @@ public class RealisticBiomeVanillaTaigaHills extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaM.java
+++ b/src/main/java/rtg/world/biome/realistic/vanilla/RealisticBiomeVanillaTaigaM.java
@@ -13,7 +13,7 @@ import rtg.api.config.BiomeConfig;
 import rtg.api.util.BlockUtil;
 import rtg.api.util.CliffCalculator;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.api.world.IRTGWorld;
 import rtg.api.world.deco.collection.DecoCollectionTaiga;
 import rtg.api.world.surface.SurfaceBase;
 import rtg.api.world.terrain.TerrainBase;
@@ -70,9 +70,9 @@ public class RealisticBiomeVanillaTaigaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public float generateNoise(RTGWorld rtgWorld, int x, int y, float border, float river) {
+        public float generateNoise(IRTGWorld rtgWorld, int x, int y, float border, float river) {
 
-            return terrainGrasslandHills(x, y, rtgWorld.simplex, rtgWorld.cell, river, vWidth, vHeight, hWidth, hHeight, bHeight);
+            return terrainGrasslandHills(x, y, rtgWorld.simplex(), rtgWorld.cell(), river, vWidth, vHeight, hWidth, hHeight, bHeight);
         }
     }
 
@@ -94,10 +94,10 @@ public class RealisticBiomeVanillaTaigaM extends RealisticBiomeVanillaBase {
         }
 
         @Override
-        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, RTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
+        public void paintTerrain(ChunkPrimer primer, int i, int j, int x, int z, int depth, IRTGWorld rtgWorld, float[] noise, float river, Biome[] base) {
 
-            Random rand = rtgWorld.rand;
-            OpenSimplexNoise simplex = rtgWorld.simplex;
+            Random rand = rtgWorld.rand();
+            OpenSimplexNoise simplex = rtgWorld.simplex();
             float p = simplex.noise2(i / 8f, j / 8f) * 0.5f;
             float c = CliffCalculator.calc(x, z, noise);
             int cliff = 0;

--- a/src/main/java/rtg/world/gen/ChunkLandscape.java
+++ b/src/main/java/rtg/world/gen/ChunkLandscape.java
@@ -1,6 +1,6 @@
 package rtg.world.gen;
 
-import rtg.world.biome.realistic.RealisticBiomeBase;
+import rtg.api.world.biome.IRealisticBiome;
 
 /**
  *
@@ -8,6 +8,6 @@ import rtg.world.biome.realistic.RealisticBiomeBase;
  */
 public class ChunkLandscape {
     public float [] noise = new float [256];
-    public RealisticBiomeBase [] biome = new RealisticBiomeBase [256];
+    public IRealisticBiome[] biome = new IRealisticBiome [256];
     public float [] river = new float [256];
 }

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -40,12 +40,13 @@ import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.*;
+import rtg.api.world.biome.IRealisticBiome;
 import rtg.world.RTGWorld;
 import rtg.util.TimeTracker;
 import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeAnalyzer;
 import rtg.world.biome.BiomeProviderRTG;
-import rtg.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;
 import rtg.world.gen.structure.MapGenScatteredFeatureRTG;
@@ -294,10 +295,10 @@ public class ChunkProviderRTG implements IChunkGenerator
         for (k = 0; k < 256; k++) {
 
             try {
-                baseBiomesList[k] = landscape.biome[k].baseBiome;
+                baseBiomesList[k] = landscape.biome[k].baseBiome();
             }
             catch (Exception e) {
-                baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome));
+                baseBiomesList[k] = biomePatcher.getPatchedBaseBiome("" + Biome.getIdForBiome(landscape.biome[k].baseBiome()));
             }
         }
         volcanoGenerator.generateMapGen(primer, worldSeed, worldObj, cmr, mapRand, cx, cz, rtgWorld.simplex, rtgWorld.cell, landscape.noise);
@@ -433,7 +434,7 @@ public class ChunkProviderRTG implements IChunkGenerator
     }
 
     private void generateTerrain(IBiomeProviderRTG cmr, int cx, int cz, ChunkPrimer primer,
-                                 RealisticBiomeBase biomes[], float[] noise) {
+                                 IRealisticBiome biomes[], float[] noise) {
 
         int h;
         for (int i = 0; i < 16; i++) {
@@ -457,7 +458,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
     }
 
-    private void replaceBlocksForBiome(int cx, int cz, ChunkPrimer primer, RealisticBiomeBase[]
+    private void replaceBlocksForBiome(int cx, int cz, ChunkPrimer primer, IRealisticBiome[]
         biomes, Biome[] base, float[] n) {
 
         ChunkGeneratorEvent.ReplaceBiomeBlocks event = new ChunkGeneratorEvent.ReplaceBiomeBlocks(
@@ -467,7 +468,7 @@ public class ChunkProviderRTG implements IChunkGenerator
 
         int i, j, depth;
         float river;
-        RealisticBiomeBase biome;
+        IRealisticBiome biome;
 
         for (i = 0; i < 16; i++) {
             for (j = 0; j < 16; j++) {
@@ -480,9 +481,9 @@ public class ChunkProviderRTG implements IChunkGenerator
                 river = -cmr.getRiverStrength(cx * 16 + i, cz * 16 + j);
                 depth = -1;
 
-                if (rtgWorld.organicBiomeGenerator.isOrganicBiome(Biome.getIdForBiome(biome.baseBiome))) {
+                if (rtgWorld.organicBiomeGenerator.isOrganicBiome(Biome.getIdForBiome(biome.baseBiome()))) {
 
-                    rtgWorld.organicBiomeGenerator.organicSurface(cx * 16 + i, cz * 16 + j, primer, biome.baseBiome);
+                    rtgWorld.organicBiomeGenerator.organicSurface(cx * 16 + i, cz * 16 + j, primer, biome.baseBiome());
                 }
                 else {
 
@@ -567,7 +568,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         TimeTracker.manager.start("Biome Layout");
 
         //Flippy McFlipperson.
-        RealisticBiomeBase biome = cmr.getBiomeDataAt(worldX + 16, worldZ + 16);
+        IRealisticBiome biome = cmr.getBiomeDataAt(worldX + 16, worldZ + 16);
         //Logger.debug("CPRTG#doPopulate: %s at %d %d", biome.baseBiome.getBiomeName(), worldX + 16, worldZ + 16);
 
         TimeTracker.manager.stop("Biome Layout");
@@ -674,7 +675,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
 
         TimeTracker.manager.start("Pools");
-        biome.rDecorator.rPopulatePreDecorate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
+        biome.rDecorator().rPopulatePreDecorate(this, worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
         TimeTracker.manager.stop("Pools");
 
         /*
@@ -762,12 +763,12 @@ public class ChunkProviderRTG implements IChunkGenerator
          */
 
         TimeTracker.manager.start("Post-decorations");
-        biome.rDecorator.rPopulatePostDecorate(worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
+        biome.rDecorator().rPopulatePostDecorate(worldObj, rand, chunkX, chunkZ, hasPlacedVillageBlocks);
         TimeTracker.manager.stop("Post-decorations");
 
         TimeTracker.manager.start("Entities");
         if (TerrainGen.populate(this, this.worldObj, this.rand, chunkX, chunkZ, hasPlacedVillageBlocks, PopulateChunkEvent.Populate.EventType.ANIMALS)) {
-            WorldEntitySpawner.performWorldGenSpawning(this.worldObj, biome.baseBiome, worldX + 8, worldZ + 8, 16, 16, this.rand);
+            WorldEntitySpawner.performWorldGenSpawning(this.worldObj, biome.baseBiome(), worldX + 8, worldZ + 8, 16, 16, this.rand);
         }
         TimeTracker.manager.stop("Entities");
 
@@ -1067,7 +1068,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         }
     }
 
-    private void generateOres(RealisticBiomeBase rb, BlockPos pos) {
+    private void generateOres(IRealisticBiome rb, BlockPos pos) {
 
         int x = pos.getX();
         int z = pos.getZ();
@@ -1078,7 +1079,7 @@ public class ChunkProviderRTG implements IChunkGenerator
             return;
         }
 
-        rb.rDecorator.decorateOres(this.worldObj, this.rand, x, z);
+        rb.rDecorator().decorateOres(this.worldObj, this.rand, x, z);
         chunkOreGenTracker.addOreChunk(pos);
     }
 

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -136,7 +136,7 @@ public class ChunkProviderRTG implements IChunkGenerator
         rtgWorld = new RTGWorld(worldObj);
         cmr = (BiomeProviderRTG) worldObj.getBiomeProvider();
         rand = new Random(seed);
-        landscapeGenerator = new LandscapeGenerator(rtgWorld);
+        landscapeGenerator = rtgWorld.landscapeGenerator;
         mapRand = new Random(seed);
         worldSeed = seed;
         volcanoGenerator = new VolcanoGenerator(seed);

--- a/src/main/java/rtg/world/gen/ChunkProviderRTG.java
+++ b/src/main/java/rtg/world/gen/ChunkProviderRTG.java
@@ -40,7 +40,7 @@ import rtg.api.RTGAPI;
 import rtg.api.config.RTGConfig;
 import rtg.api.dimension.DimensionManagerRTG;
 import rtg.api.util.*;
-import rtg.api.world.RTGWorld;
+import rtg.world.RTGWorld;
 import rtg.util.TimeTracker;
 import rtg.world.WorldTypeRTG;
 import rtg.world.biome.BiomeAnalyzer;

--- a/src/main/java/rtg/world/gen/LandscapeGenerator.java
+++ b/src/main/java/rtg/world/gen/LandscapeGenerator.java
@@ -11,7 +11,7 @@ import rtg.api.util.noise.OpenSimplexNoise;
 import rtg.world.RTGWorld;
 import rtg.util.TimeTracker;
 import rtg.world.biome.BiomeAnalyzer;
-import rtg.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import rtg.world.biome.realistic.RealisticBiomePatcher;
 
@@ -76,7 +76,7 @@ class LandscapeGenerator {
         int cx2 = cx&15;
         int cz2 = cz&15;
         ChunkLandscape target = this.landscape(cmr, cx-cx2, cz-cz2);
-        return Biome.getIdForBiome(target.biome[cx2*16+cz2].baseBiome);
+        return Biome.getIdForBiome(target.biome[cx2*16+cz2].baseBiome());
     }
 
     /*
@@ -104,7 +104,7 @@ class LandscapeGenerator {
         for(int i = -sampleSize; i < sampleSize + 5; i++) {
             for(int j = -sampleSize; j < sampleSize + 5; j++) {
                 biomeData[(i + sampleSize) * sampleArraySize + (j + sampleSize)] =
-                Biome.getIdForBiome(cmr.getBiomeDataAt(cx + ((i * 8)), cz + ((j * 8))).baseBiome);
+                Biome.getIdForBiome(cmr.getBiomeDataAt(cx + ((i * 8)), cz + ((j * 8))).baseBiome());
             }
         }
 

--- a/src/main/java/rtg/world/gen/LandscapeGenerator.java
+++ b/src/main/java/rtg/world/gen/LandscapeGenerator.java
@@ -20,7 +20,7 @@ import rtg.world.biome.realistic.RealisticBiomePatcher;
  *
  * @author Zeno410
  */
-class LandscapeGenerator {
+public class LandscapeGenerator {
     private final int sampleSize = 8;
     private final int sampleArraySize;
     private final int[] biomeData;
@@ -35,7 +35,7 @@ class LandscapeGenerator {
     private final WeakHashMap<ChunkPos,float[]> cache = new WeakHashMap();
     private MesaBiomeCombiner mesaCombiner = new MesaBiomeCombiner();
 
-    LandscapeGenerator(RTGWorld rtgWorld) {
+    public LandscapeGenerator(RTGWorld rtgWorld) {
         this.rtgWorld = rtgWorld;
         sampleArraySize = sampleSize * 2 + 5;
         biomeData = new int[sampleArraySize * sampleArraySize];
@@ -72,7 +72,7 @@ class LandscapeGenerator {
         return (biomeMapCoordinate - sampleSize)*8;
     }
 
-    int getBiomeDataAt(IBiomeProviderRTG cmr, int cx, int cz) {
+    public int getBiomeDataAt(IBiomeProviderRTG cmr, int cx, int cz) {
         int cx2 = cx&15;
         int cz2 = cz&15;
         ChunkLandscape target = this.landscape(cmr, cx-cx2, cz-cz2);

--- a/src/main/java/rtg/world/gen/LandscapeGenerator.java
+++ b/src/main/java/rtg/world/gen/LandscapeGenerator.java
@@ -8,7 +8,7 @@ import net.minecraft.world.biome.Biome;
 import rtg.api.util.TimedHashMap;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.api.world.RTGWorld;
+import rtg.world.RTGWorld;
 import rtg.util.TimeTracker;
 import rtg.world.biome.BiomeAnalyzer;
 import rtg.world.biome.IBiomeProviderRTG;

--- a/src/main/java/rtg/world/gen/VolcanoGenerator.java
+++ b/src/main/java/rtg/world/gen/VolcanoGenerator.java
@@ -10,7 +10,7 @@ import rtg.api.config.RTGConfig;
 import rtg.api.util.LimitedSet;
 import rtg.api.util.noise.CellNoise;
 import rtg.api.util.noise.OpenSimplexNoise;
-import rtg.world.biome.IBiomeProviderRTG;
+import rtg.api.world.biome.IBiomeProviderRTG;
 import rtg.world.biome.realistic.RealisticBiomeBase;
 import static rtg.world.biome.realistic.RealisticBiomeBase.getBiome;
 import rtg.world.biome.realistic.RealisticBiomePatcher;


### PR DESCRIPTION
As per the discussion on Discord, this is the new candidate for making `LandscapeGenerator` accessible from `RTGWorld`.

To achieve this, I added an `IRTGWorld` interface to the API, de-exposed `RTGWorld`, and exposed `IBiomeProviderRTG` to the API.

Then I added `int getBiomeDataAt(IBiomeProviderRTG cmr, int cx, int cz);` to `IRTGWorld`, which means that we now have access to `LandscapeGenerator` internally from any `RTGWorld` object, and externally we have the ability to fetch biomes.

If this looks good, I'll merge it into `1.10.2-dev` and update the `1.10.2-surface-bleed` branch so we can finish it off.