### PR TITLE
Fix allowed DimensionTypes

### DIFF
--- a/src/main/java/rtg/event/EventManagerRTG.java
+++ b/src/main/java/rtg/event/EventManagerRTG.java
@@ -8,12 +8,11 @@ import net.minecraft.block.BlockSapling;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.DimensionType;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraft.world.gen.IChunkGenerator;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
 import net.minecraftforge.event.terraingen.OreGenEvent;
@@ -405,8 +404,20 @@ public class EventManagerRTG {
         @SubscribeEvent
         public void onWorldLoad(WorldEvent.Load event) {
 
-            if (!event.getWorld().isRemote && event.getWorld().provider.getDimension() == 0) {
-                Logger.info("World Seed: " + event.getWorld().getSeed());
+            World world = event.getWorld();
+            if (!world.isRemote) {
+
+                if (event.getWorld().provider.getDimension() == 0) {
+                    Logger.info("World Seed: " + event.getWorld().getSeed());
+                }
+
+                Logger.debug("WorldEvent.Load: DimID: {}, DimType: {}, WorldType: {}, BiomeProvider: {}, IChunkGenerator: {}",
+                    world.provider.getDimension(),
+                    world.provider.getDimensionType(),
+                    world.getWorldType().getClass().getSimpleName(),
+                    world.provider.getBiomeProvider().getClass().getSimpleName(),
+                    ((ChunkProviderServer)world.getChunkProvider()).chunkGenerator.getClass().getSimpleName()
+                );
             }
         }
 
@@ -415,13 +426,17 @@ public class EventManagerRTG {
 
             World world = event.getWorld();
             if (!world.isRemote) {
+
                 // Cached instances of RTGWorld need to be removed because they contain a strong reference to the World object, which should be GC'd.
-                if (!RTGWorld.removeInstance(world) && RTGAPI.checkWorldType(world.getWorldType())) {
-                    DimensionType dimtype = DimensionManager.getProviderType(world.provider.getDimension());
-                    if (dimtype != DimensionType.NETHER && dimtype != DimensionType.THE_END) {
-                        Logger.warn("Failed to remove a cached instance of RTGWorld (non-existant) for dimension: {}", world.provider.getDimension());
-                    }
-                }
+                RTGWorld.removeInstance(world);
+
+                Logger.debug("WorldEvent.Unload: DimID: {}, DimType: {}, WorldType: {}, BiomeProvider: {}, IChunkGenerator: {}",
+                    world.provider.getDimension(),
+                    world.provider.getDimensionType(),
+                    world.getWorldType().getClass().getSimpleName(),
+                    world.provider.getBiomeProvider().getClass().getSimpleName(),
+                    ((ChunkProviderServer)world.getChunkProvider()).chunkGenerator.getClass().getSimpleName()
+                );
             }
         }
     }

--- a/src/main/java/rtg/world/WorldTypeRTG.java
+++ b/src/main/java/rtg/world/WorldTypeRTG.java
@@ -3,7 +3,9 @@ package rtg.world;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.BiomeProvider;
+import net.minecraft.world.gen.ChunkGeneratorOverworld;
 import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import rtg.api.RTGAPI;
@@ -13,6 +15,7 @@ import rtg.world.biome.BiomeProviderRTG;
 import rtg.world.gen.ChunkGeneratorRTG;
 
 
+@SuppressWarnings("EqualsAndHashcode")
 public final class WorldTypeRTG extends WorldType {
 
     private static WorldTypeRTG INSTANCE;
@@ -35,24 +38,49 @@ public final class WorldTypeRTG extends WorldType {
     @Override
     public BiomeProvider getBiomeProvider(World world) {
 
-        if (RTGAPI.isAllowedDimensionType(world.provider.getDimension())) {
-            Logger.debug("WorldTypeRTG#getBiomeProvider() returning BiomeProviderRTG");
+        // TODO: It may be appropriate to add a config setting for a DimensionType whitelist in the future.
+        if (RTGAPI.isAllowedDimensionType(world.provider.getDimension()) ||
+            DimensionManager.getProviderType(world.provider.getDimension()).getSuffix().equals("_rtg") ||
+            DimensionManager.getProviderType(world.provider.getDimension()).name().startsWith("jed_surface")) {
+
+            Logger.debug("WorldType#getBiomeProvider: Allowed DimensionType detected (ID:{}, Type:{}, Suffix:{}).. returning BiomeProviderRTG",
+                world.provider.getDimension(),
+                world.provider.getDimensionType(),
+                DimensionManager.getProviderType(world.provider.getDimension()).getSuffix()
+            );
             return new BiomeProviderRTG(RTGWorld.getInstance(world));
         }
         else {
-            throw new RuntimeException(String.format("Illegal DimensionType (%s) for RTG WorldType", world.provider.getDimensionType().getName()));
+            Logger.debug("WorldType#getBiomeProvider: DimensionType not in whitelist (ID:{}, Type:{}, Suffix:{}).. returning BiomeProvider",
+                world.provider.getDimension(),
+                world.provider.getDimensionType(),
+                DimensionManager.getProviderType(world.provider.getDimension()).getSuffix()
+            );
+            return new BiomeProvider(world.getWorldInfo());
         }
     }
 
     @Override
     public IChunkGenerator getChunkGenerator(World world, String generatorOptions) {
 
-        if (RTGAPI.isAllowedDimensionType(world.provider.getDimension())) {
-            Logger.debug("WorldTypeRTG#getChunkGenerator() returning ChunkGeneratorRTG for Dim {}", world.provider.getDimension());
+        if (RTGAPI.isAllowedDimensionType(world.provider.getDimension()) ||
+            DimensionManager.getProviderType(world.provider.getDimension()).getSuffix().equals("_rtg") ||
+            DimensionManager.getProviderType(world.provider.getDimension()).name().startsWith("jed_surface")) {
+
+            Logger.debug("WorldType#getChunkGenerator: Allowed DimensionType detected (ID:{}, Type:{}, Suffix:{}).. returning ChunkGeneratorRTG",
+                world.provider.getDimension(),
+                world.provider.getDimensionType(),
+                DimensionManager.getProviderType(world.provider.getDimension()).getSuffix()
+            );
             return new ChunkGeneratorRTG(RTGWorld.getInstance(world));
         }
         else {
-            throw new RuntimeException(String.format("Illegal DimensionType (%s) for RTG WorldType", world.provider.getDimensionType().getName()));
+            Logger.debug("WorldType#getChunkGenerator: DimensionType not in whitelist (ID:{}, Type:{}, Suffix:{}).. returning ChunkGeneratorOverworld",
+                world.provider.getDimension(),
+                world.provider.getDimensionType(),
+                DimensionManager.getProviderType(world.provider.getDimension()).getSuffix()
+            );
+            return new ChunkGeneratorOverworld(world, world.getWorldInfo().getSeed(), world.getWorldInfo().isMapFeaturesEnabled(), world.getWorldInfo().getGeneratorOptions());
         }
     }
 


### PR DESCRIPTION
This should now work in all OVERWORLD `DimensionType`s.
This should work in all surface based JED `DimensionType`s
This should work in any DimensionType that has the suffix '_rtg'

Closes #1128 
