### PR TITLE
Fix OpenSimplex performance #1341

### DIFF
--- a/src/main/java/rtg/api/util/noise/OpenSimplexNoise.java
+++ b/src/main/java/rtg/api/util/noise/OpenSimplexNoise.java
@@ -351,7 +351,8 @@ public class OpenSimplexNoise implements SimplexNoise {
 
             double extrp = GRADIENTS_2D[gi] * dx + GRADIENTS_2D[gi + 1] * dy;
 
-            value += Math.pow(attn, 4) * extrp;
+            attn *= attn;
+            value += attn * attn * extrp;
         }
         return value;
     }
@@ -408,7 +409,8 @@ public class OpenSimplexNoise implements SimplexNoise {
 
                 double valuePart = GRADIENTS_3D[i] * dx + GRADIENTS_3D[i + 1] * dy + GRADIENTS_3D[i + 2] * dz;
 
-                value += Math.pow(attn, 4) * valuePart;
+                attn *= attn;
+                value += attn * attn * valuePart;
             }
             c = c.getNext();
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8829856/71055032-24e7d800-2122-11ea-9535-9c3a43ee5142.png)

Reduces runtime from ~675ns per evaluation, down to ~87ns per evaluation

#1341